### PR TITLE
Added scripts for converting from notebook to markdown.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,19 @@ Please use the following style guidelines when making contributions.
   the notebook.
 * A horizontal rule should appear between sections that begin with a level 2
   heading.
+* When a lab participant needs to open a file for editing in a notebook, do not
+  use jupyter's edit links, but rather use the following convention:
+  `**<link text>** (File -> Open -> <path-to-file>)`. This eliminates issues
+  with links breaking when jupyter is launched from a different directory. The
+  `generate_markdown` script will look for this convention to fix the links in
+  markdown.
+* If a cell should not be included in the generated markdown version of the
+  notebook, that cell should be tagged with `remove_cell` by selecting 
+  `View -> Cell Toolbar -> Tags` and adding it. After doing this, change back
+  to `None` from the same menu.
+* After updating a notebook, from a terminal run the
+  `<basedir>/scripts/generate_markdown.sh` script to create an updated markdown
+  version of the file.
 
 ## Contributing Labs/Modules
 

--- a/labs/module2/English/C/README.md
+++ b/labs/module2/English/C/README.md
@@ -1,0 +1,283 @@
+# Profiling OpenACC Code
+
+This lab is intended for C/C++ programmers. If you prefer to use Fortran, click [this link.](../Fortran/README.md)
+
+You will receive a warning five minutes before the lab instance shuts down. At this point, make sure to save your work! If you are about to run out of time, please see the [Post-Lab](#Post-Lab-Summary) section for saving this lab to view offline later.
+
+Don't forget to check out additional [OpenACC Resources](https://www.openacc.org/resources) and join our [OpenACC Slack Channel](https://www.openacc.org/community#slack) to share your experience and get more help from the community.
+
+---
+Let's execute the cell below to display information about the GPUs running on the server by running the `pgaccelinfo` command, which ships with the PGI compiler that we will be using. To do this, execute the cell block below by giving it focus (clicking on it with your mouse), and hitting Ctrl-Enter, or pressing the play button in the toolbar above.  If all goes well, you should see some output returned below the grey cell.
+
+
+```bash
+$ pgaccelinfo
+```
+
+---
+## Introduction
+
+Our goal for this lab is to learn what exactly code profiling is, and how we can use it to help us write powerful parallel programs.  
+  
+  
+  
+![development-cycle.png](../images/development-cycle.png)
+
+This is the OpenACC 3-Step development cycle.
+
+**Analyze** your code to determine most likely places needing parallelization or optimization.
+
+**Parallelize** your code by starting with the most time consuming parts and check for correctness.
+
+**Optimize** your code to improve observed speed-up from parallelization.
+
+We are currently tackling the **analyze** step. We will use PGI's code profiler (PGProf) to get an understanding of a relatively simple sample code before moving onto the next two steps.
+
+---
+
+## Run the Code
+
+Our first step to analyzing this code is to run it. We need to record the results of our program before making any changes so that we can compare them to the results from the parallel code later on. It is also important to record the time that the program takes to run, as this will be our primary indicator to whether or not our parallelization is improving performance.
+
+### Compiling the Code with PGI
+
+We are using the PGI compiler to compiler our code. You will not need to memorize the compiler commands to complete this lab, however, they will be helpful to know if you want to parallelize your own personal code with OpenACC.
+
+**pgcc**      : this is the command to compile C code  
+**pgc++**     : this is the command to compile C++ code  
+**pgfortran** : this is the command to compile Fortran code  
+**-fast**     : this compiler flag will allow the compiler to perform additional optimizations to our code
+
+
+```bash
+$ pgcc  -fast -o laplace -Mprof=ccff jacobi.c laplace2d.c && echo "Compilation Successful!" && ./laplace
+```
+
+### Understanding Code Results
+
+The output from our program will make more sense as we analyze the code. The most important thing to keep in mind is that we need these output values to stay consistent. If these outputs change during any point while we parallelize our code, we know we've made a mistake. For simplicity, focus on the last output, which occurred at iteration 900. It is also helpful to record the time the program took to run. Our goal while parallelizing the code is ultimately to make it faster, so we need to know our "base runtime" in order to know if the code is running faster.
+
+---
+
+## Analyze the Code
+
+Now that we know how long the code took to run and what the code's output looks like, we should be able to view the code with a decent idea of what is happening. The code is contained within two files, which you may open and view.
+
+[jacobi.c](../../../../edit/module2/English/C/jacobi.c)  
+[laplace2d.c](../../../../edit/module2/English/C/laplace2d.c)  
+  
+You may read through these two files on your own, but we will also highlight the most important parts below in the "Code Breakdown".
+
+### Code Description
+
+The code simulates heat distribution across a 2-dimensional metal plate. In the beginning, the plate will be unheated, meaning that the entire plate will be room temperature. A constant heat will be applied to the edge of the plate and the code will simulate that heat distributing across the plate over time.  
+
+This is a visual representation of the plate before the simulation starts:  
+  
+![plate1.png](../images/plate1.png)  
+  
+We can see that the plate is uniformly room temperature, except for the top edge. Within the [laplace2d.c](../C/laplace2d.c) file, we see a function called `initialize`. This function is what "heats" the top edge of the plate. 
+  
+```cpp
+void initialize(double *restrict A, double *restrict Anew, int m, int n)  
+{  
+    memset(A, 0, n * m * sizeof(double));  
+    memset(Anew, 0, n * m * sizeof(double));  
+  
+    for(int i = 0; i < m; i++){  
+        A[i] = 1.0;  
+        Anew[i] = 1.0;  
+    }  
+}  
+```
+
+After the top edge is heated, the code will simulate the heat distributing across the length of the plate. We will keep the top edge at a constant heat as the simulation progresses.
+
+This is the plate after several iterations of our simulation:  
+  
+![plate2.png](../images/plate2.png) 
+
+That's the theory: simple heat distribution. However, we are more interested in how the code works. 
+
+### Code Breakdown
+
+The 2-dimensional plate is represented by a 2-dimensional array containing double-precision floating point values. These doubles represent temperature; 0.0 is room temperature, and 1.0 is our max temperature. The 2-dimensional plate has two states, one represents the current temperature, and one represents the expected temperature values at the next step in our simulation. These two states are represented by arrays **`A`** and **`Anew`** respectively. The following is a visual representation of these arrays, with the top edge "heated".
+
+![plate_sim2.png](../images/plate_sim2.png)  
+    
+Simulating this state in two arrays is very important for our **`calcNext`** function. Our calcNext is essentially our "simulate" function. calcNext will look at the inner elements of A (meaning everything except for the edges of the plate) and update each elements temperature based on the temperature of its neighbors.  If we attempted to calculate in-place (using only **`A`**), then each element would calculate its new temperature based on the updated temperature of previous elements. This data dependency not only prevents parallelizing the code, but would also result in incorrect results when run in serial. By calculating into the temporary array **`Anew`** we ensure that an entire step of our simulation has completed before updating the **`A`** array.
+
+![plate_sim3.png](../images/plate_sim3.png)  
+
+Below is the `calcNext` function:
+
+```cpp
+01 double calcNext(double *restrict A, double *restrict Anew, int m, int n)
+02 {
+03     double error = 0.0;  
+04     for( int j = 1; j < n-1; j++)  
+05     {  
+06        for( int i = 1; i < m-1; i++ )   
+07        {  
+08            Anew[OFFSET(j, i, m)] = 0.25 * ( A[OFFSET(j, i+1, m)] + A[OFFSET(j, i-1, m)]  
+09                                           + A[OFFSET(j-1, i, m)] + A[OFFSET(j+1, i, m)]);  
+10            error = fmax( error, fabs(Anew[OFFSET(j, i, m)] - A[OFFSET(j, i , m)]));  
+11        }  
+12    }  
+13    return error;  
+14 }  
+```
+
+We see on lines 07 and 08 where we are calculating the value of `Anew` at `i,j` by averaging the current values of its neighbors. Line 09 is where we calculate the current rate of change for the simulation by looking at how much the `i,j` element changed during this step and finding the maximum value for this `error`. This allows us to short-circuit our simulation if it reaches a steady state before we've completed our maximum number of iterations.
+
+Lastly, our `swap` function will copy the contents of `Anew` to `A`.
+
+```cpp
+01 void swap(double *restrict A, double *restrict Anew, int m, int n)
+02 {	
+03    for( int j = 1; j < n-1; j++)
+04    {
+05        for( int i = 1; i < m-1; i++ )
+06        {
+07            A[OFFSET(j, i, m)] = Anew[OFFSET(j, i, m)];    
+08        }
+09    }
+10 }
+```
+
+---
+
+## Profile the Code
+
+By now you should have a good idea of what the code is doing. If not, go spend a little more time in the previous sections to ensure you understand the code before moving forward. Now it's time to profile the code to get a better understanding of where the application is spending its runtime. To profile our code we will be using PGPROF. PGPROF provides both command line and visual profiler. It comes comes with the PGI compiler. 
+
+We will start by profiling the laplace executable that we created earlier using the command line option first. Run the pgprof command: 
+
+
+
+
+
+```bash
+$ pgprof ./laplace
+```
+
+We can see the time that each individual portion of our code took to run. This information is important because it allows us to make educated decisions about which parts of our code to optimize first. To get the bang for our buck, we want to focus on the most time-consuming parts of the code. Next, we will compile, run, and profile a parallel version of the code, and analyze the differences.
+
+### Optional - Where is the c_mcopy8 coming from?
+
+When we compiled our code earlier, we omitted any sort of compiler feedback. It turns out that even with a sequential code, the compiler is performing a lot of optimizations. If you compile the code again with the `-Minfo=opt` flag, which instructs  the compiler to print additional information how it optimized the code, then it will become more obvious where this strange routine came from.. Afterwards, you should see that the `c_mcopy8` is actually an optimzation that is being applied to the `swap` function. Notice in the output below that at line 64 of `laplace2d.c`, which happens inside the `swap` routine, that the compiler determined that our loops are performing a memory copy, which it believes can be performed more efficiently by calling the `c_mcopy8` function instead.
+
+```cpp
+laplace2d.c:
+swap:
+     63, Memory copy idiom, loop replaced by call to __c_mcopy8
+```
+
+
+```bash
+$ pgcc -fast -Minfo=opt -o laplace jacobi.c laplace2d.c
+```
+
+---
+
+## Run Our Parallel Code on Multicore CPU
+
+In a future lab you will run parallelize the code to run on a multicore CPU. This is the simplest starting point, since it doesn't require us to think about copying our data between different memories. So that you can experience profiling with PGProf on a multicore CPU, a parallel version of the code has been provided. You will be able to parallelize the code yourself in the next lab.
+
+
+```bash
+$ pgcc -fast -ta=multicore -Minfo=accel -o laplace_parallel ./solutions/parallel/jacobi.c ./solutions/parallel/laplace2d.c && ./laplace_parallel
+```
+
+### Compiling Multicore Code using PGI
+
+Again, you do not need to memorize the compiler commands to complete this lab. Though, if you want to use OpenACC with your own personal code, you will want to learn them.
+
+**-ta** : This flag will tell the compiler to compile our code for a specific parallel hardware. TA stands for *"Target Accelerator"*, an accelerator being any device that accelerates performance (in our case, this means parallel hardware.) Omitting the -ta flag will cause the code to compile sequentially.  
+**-ta=multicore** will tell the compiler to parallelize the code specifically for a multicore CPU.  
+**-Minfo** : This flag will tell the compiler to give us some feedback when compiling the code.  
+**-Minfo=accel** : will only give us feedback about the parallelization of our code.  
+**-Minfo=opt** : will give us feedback about sequential optimizations.  
+**-Minfo=all** : will give all feedback; this includes feedback about parallelization, sequential optimizations, and even parts of the code that couldn't be optimized for one reason or another.  
+
+If you would like to see the c_mcopy8 from earlier, try switching the Minfo flag with **-Minfo=accel,opt**.
+
+---
+
+## Profiling Multicore Code
+
+We will use PGProf visual profiler this time to get a more graphical view of the profile. [Click here](/vnc/vnc.html) to open a new browser tab with a virtual desktop runnning the PGProf profiler. Normally you would open this program on your local machine by running the `pgprof` command or choosing it from your installed applications.
+
+After accessing the URL, the first screen will ask you to connect to VNC ![connect.png](../images/connect.png)
+You will be asked to enter the password. Please enter "openacc" as the password ![password.png](../images/password.png)
+We have already run Visual Profiler for you and the first screen you see is to choose a workspace. You can keep the default workspace and press enter ![workspace.png](../images/workspace.png)
+
+We will start by profiling the laplace executable that we created earlier. To do this, Select File > New Session. After doing this you should see a pop-up like the one in the picture below.
+
+![pgprof1.png](../images/pgprof1.png) 
+
+Then where is says "File: Enter Executable File [required]", select "Browse". Then select File Systems > home > openacc > labs > module2 > English > C.
+
+Select our "laplace" executable file. 
+
+![location.png](../images/location.png)
+
+Then select "Next", followed by "Finished". 
+
+![pgprof4.png](../images/pgprof4.PNG) 
+
+
+Follow the steps from earlier to profile the code with PGPROF, however, select the **`laplace_parallel`** executable this time instead of **`laplace`**. If you have closed the noVNC client, you can reopen it by <a href="/vnc" target="_blank">clicking this link</a>.
+
+This is the view that we are greeted with when profiling a multicore application.
+
+![pgprof_parallel1.PNG](../images/pgprof_parallel1.PNG)
+
+The first difference we see is the blue "timeline." This timeline represents when our program is executing something on the parallel hardware. This means that every call to `calcNext` and `swap` should be represented by a blue bar. 
+
+This is the main idea behind parallel programming. When you consider the **TOTAL** computation time, it will take almost equivalent time to our sequential program, however the application runtime decreases due to the fact that we can now execute portions of our code in parallel by spreading the work across multiple threads.
+
+---
+
+## Conclusion
+
+Now we have a good understanding of how our program is running, and which parts of the program are time consuming. In the next lab, we will parallelize our program using OpenACC.
+
+We are working on a very simple code that is specifically used for teaching purposes. Meaning that, in terms of complexity, it can be fairly underwhelming. Profiling code will become exponentially more useful if you chose to work on a "real-world" code; a code with possibly hundreds of functions, or millions of lines of code. Profiling may seem trivial when we only have 4 functions, and our entire code is contained in only two files, however, profiling will be one of your greatest assets when parallelizing real-world code.
+
+---
+
+## Bonus Task
+
+For right now, we are focusing on multicore CPUs. Eventually, we will transition to GPUs. If you are familiar with GPUs, and would like to play with a GPU profile, then feel free to try this bonus task. If you do not want to complete this task now, you will have an opportunity in later labs (where we will also explain more about what is happening.)
+
+Run this script to compile/run our code on a GPU.
+
+
+```bash
+$ pgcc -fast -ta=tesla -Minfo=accel -o laplace_gpu ./solutions/gpu/jacobi.c ./solutions/gpu/laplace2d.c && ./laplace_gpu
+```
+
+Now, within PGPROF, select File > New Session. Follow the same steps as earlier, except select the **`laplace_gpu`** executable. If you closed the noVNC window, you can reopen it by <a href="/vnc" target="_blank">clicking this link</a>.
+
+Happy profiling!
+
+---
+
+## Post-Lab Summary
+
+If you would like to download this lab for later viewing, it is recommend you go to your browsers File menu (not the Jupyter notebook file menu) and save the complete web page.  This will ensure the images are copied down as well.
+
+You can also execute the following cell block to create a zip-file of the files you've been working on, and download it with the link below.
+
+
+```python
+%%bash
+rm -f openacc_files.zip
+zip -r openacc_files.zip *
+```
+
+**After** executing the above zip command, you should be able to download the zip file [here](files/openacc_files.zip)
+
+# Licensing
+This material is released by NVIDIA Corporation under the Creative Commons Attribution 4.0 International (CC BY 4.0).

--- a/labs/module2/English/Fortran/README.md
+++ b/labs/module2/English/Fortran/README.md
@@ -1,0 +1,278 @@
+# Profiling OpenACC Code
+
+This lab is intended for Fortran programmers. If you prefer to use C/C++, click [this link.](../C/README.md)
+
+The following timer counts down to a five minute warning before the lab instance shuts down.  You should get a pop up at the five minute warning reminding you to save your work!  If you are about to run out of time, please see the [Post-Lab](#Post-Lab-Summary) section for saving this lab to view offline later.
+
+Don't forget to check out additional [OpenACC Resources](https://www.openacc.org/resources) and join our [OpenACC Slack Channel](https://www.openacc.org/community#slack) to share your experience and get more help from the community.
+
+---
+Let's execute the cell below to display information about the GPUs running on the server by running the `pgaccelinfo` command, which ships with the PGI compiler that we will be using. To do this, execute the cell block below by giving it focus (clicking on it with your mouse), and hitting Ctrl-Enter, or pressing the play button in the toolbar above.  If all goes well, you should see some output returned below the grey cell.
+
+
+```bash
+$ pgaccelinfo
+```
+
+---
+## Introduction
+
+Our goal for this lab is to learn what exactly code profiling is, and how we can use it to help us write powerful parallel programs.  
+  
+  
+  
+![development-cycle.png](../images/development-cycle.png)
+
+This is the OpenACC 3-Step development cycle.
+
+**Analyze** your code to determine most likely places needing parallelization or optimization.
+
+**Parallelize** your code by starting with the most time consuming parts and check for correctness.
+
+**Optimize** your code to improve observed speed-up from parallelization.
+
+We are currently tackling the **analyze** step. We will use PGI's code profiler (PGProf) to get an understanding of a relatively simple sample code before moving onto the next two steps.
+
+## Run the Code
+
+Our first step to analyzing this code is to run it. We need to record the results of our program before making any changes so that we can compare them to the results from the parallel code later on. It is also important to record the time that the program takes to run, as this will be our primary indicator to whether or not our parallelization is improving performance.
+
+### Compiling Code with PGI
+
+We are using the PGI compiler to compiler our code. You will not need to memorize the compiler commands to complete this lab, however, they will be helpful to know if you want to parallelize your own personal code with OpenACC.
+
+**pgcc**      : this is the command to compile C code  
+**pgc++**     : this is the command to compile C++ code  
+**pgfortran** : this is the command to compile Fortran code  
+**-fast**     : this compiler flag will allow the compiler to perform additional optimizations to our code
+
+
+```bash
+$ pgfortran -fast -o laplace laplace2d.f90 jacobi.f90 && echo "Compilation Successful!" && ./laplace
+```
+
+### Understanding Code Results
+
+The output from our program will make more sense as we analyze the code. The most important thing to keep in mind is that we need these output values to stay consistent. If these outputs change during any point while we parallelize our code, we know we've made a mistake. For simplicity, focus on the last output, which occurred at iteration 900. It is also helpful to record the time the program took to run. Our goal while parallelizing the code is ultimately to make it faster, so we need to know our "base runtime" in order to know if the code is running faster.
+
+## Analyze the Code
+
+Now that we know how long the code took to run, and what the code's output looks like, we should be able to view the code with a decent idea of what is happening. The code is contained within two files, which you may open and view.
+
+[jacobi.f90](../Fortran/jacobi.f90)  
+[laplace2d.f90](../Fortran/laplace2d.f90)  
+  
+You may read through these two files on your own, but we will also highlight the most important parts below in the "Code Breakdown".
+
+### Code Description
+
+The code simulates heat distribution across a 2-dimensional metal plate. In the beginning, the plate will be unheated, meaning that the entire plate will be room temperature. Then, a constant heat will be applied to the edge of the plate, then the code will simulate that heat distributing across the plate.  
+
+This is a visual representation of the plate before the simulation starts:  
+  
+![plate1.png](../images/plate1.png)  
+  
+We can see that the plate is uniformly room temperature, except for the top edge. Within the [laplace2d.f90](../Fortran/laplace2d.f90) file, we see a subroutine called `initialize`. This function is what "heats" the top edge of the plate. 
+  
+```fortran
+    subroutine initialize(A, Anew, m, n)
+      integer, parameter :: fp_kind=kind(1.0d0)
+      real(fp_kind),allocatable,intent(out)   :: A(:,:)
+      real(fp_kind),allocatable,intent(out)   :: Anew(:,:)
+	  integer,intent(in)          :: m, n
+
+      allocate ( A(0:n-1,0:m-1), Anew(0:n-1,0:m-1) )
+
+      A    = 0.0_fp_kind
+      Anew = 0.0_fp_kind
+
+      A(0,:)    = 1.0_fp_kind
+      Anew(0,:) = 1.0_fp_kind
+    end subroutine initialize
+```
+
+After the top edge is heated, the code will simulate the heat distributing across the length of the plate. We will keep the top edge at a constant heat as the simulation progresses.
+
+This is the plate after several iterations of our simulation:  
+  
+![plate2.png](../images/plate2.png) 
+
+That's the theory: simple heat distribution. However, we are more interested in how the code works. 
+
+### Code Breakdown
+
+The 2-dimensional plate is represented by a 2-dimensional array containing double values. These doubles represent temperature; 0.0 is room temperature, and 1.0 is our max temperature. The 2-dimensional plate has two states, one represents the current temperature, and one represents the expected temperature values at the next step in our simulation. These two states are represented by arrays **`A`** and **`Anew`** respectively. The following is a visual representation of these arrays, with the top edge "heated".
+
+![plate_sim2.png](../images/plate_sim2.png)  
+    
+Simulating this state in two arrays is very important for our `calcNext` function. Our calcNext is essentially our "simulate" function. calcNext will look at the inner elements of A (meaning everything except for the edges of the plate) and update each elements temperature based on the temperature of its neighbors.  If we attempted to calculate in-place (using only `A`), then each element would calculate its new temperature based on the updated temperature of previous elements. This data dependency not only prevents parallelizing the code, but would also result in incorrect results when run in serial. By calculating into the temporary array `Anew` we ensure that an entire step of our simulation has completed before updating the `A` array.
+
+![plate_sim3.png](../images/plate_sim3.png)  
+
+This is the `calcNext` function:
+
+```fortran
+01 function calcNext(A, Anew, m, n)
+02   integer, parameter          :: fp_kind=kind(1.0d0)
+03   real(fp_kind),intent(inout) :: A(0:n-1,0:m-1)
+04   real(fp_kind),intent(inout) :: Anew(0:n-1,0:m-1)
+05   integer,intent(in)          :: m, n
+06   integer                     :: i, j
+07   real(fp_kind)               :: error
+08	  
+09   error=0.0_fp_kind
+10	  
+11   do j=1,m-2
+12     do i=1,n-2
+13        Anew(i,j) = 0.25_fp_kind * ( A(i+1,j  ) + A(i-1,j  ) + &
+14                                     A(i  ,j-1) + A(i  ,j+1) )
+15        error = max( error, abs(Anew(i,j)-A(i,j)) )
+16     end do
+17   end do
+18   calcNext = error
+19 end function calcNext
+```
+
+We see on lines 13 and 14 where we are calculating the value of `Anew` at `i,j` by averaging the current values of its neighbors. Line 09 is where we calculate the current rate of change for the simulation by looking at how much the `i,j` element changed during this step and finding the maximum value for this `error`. This allows us to short-circuit our simulation if it reaches a steady state before we've completed our maximum number of iterations.
+
+Lastly, our `swap` subroutine will copy the contents of `Anew` to `A`.
+
+```fortran
+01 subroutine swap(A, Anew, m, n)
+02   integer, parameter        :: fp_kind=kind(1.0d0)
+03   real(fp_kind),intent(out) :: A(0:n-1,0:m-1)
+04   real(fp_kind),intent(in)  :: Anew(0:n-1,0:m-1)
+05   integer,intent(in)        :: m, n
+06   integer                   :: i, j
+07 
+08   do j=1,m-2
+09     do i=1,n-2
+10       A(i,j) = Anew(i,j)
+11     end do
+12   end do
+13 end subroutine swap
+```
+
+
+## Profile the Code
+
+By now you should have a good idea of what the code is doing. If not, go spend a little more time in the previous sections to ensure you understand the code before moving forward. Now it's time to profile the code to get a better understanding of where the application is spending its runtime. To profile our code we will be using PGPROF. PGPROF provides both command line and visual profiler. It comes comes with the PGI compiler. 
+
+We will start by profiling the laplace executable that we created earlier using the command line option first. Run the pgprof command: 
+
+
+```bash
+$ pgprof ./laplace
+```
+
+We can see the time that each individual portion of our code took to run. This information is important because it allows us to make educated decisions about which parts of our code to optimize first. To get the bang for our buck, we want to focus on the most time-consuming parts of the code. Next, we will compiler, run, and profile a parallel version of the code, and analyze the differences.
+
+### Optional - Where is the __c_mcopy8 coming from?
+
+When we compiled our code earlier, we omitted any sort of compiler feedback. It turns out that even with a sequential code, the compiler is performing a lot of optimizations. If you compile the code again with the `-Minfo=opt` flag, which instructs  the compiler to print additional information how it optimized the code, then it will become more obvious where this strange routine came from. Afterwards, you should see that the `__c_mcopy8` is actually an optimzation that is being applied to the **`swap`** function. Notice in the output below that at line 64 of `laplace2d.c`, which happens inside the `swap` routine, that the compiler determined that our loops are performing a memory copy, which it believes can be performed more efficiently by calling the `__c_mcopy8` function instead.
+
+```
+laplace2d.f90:
+swap:
+     76, Memory copy idiom, loop replaced by call to __c_mcopy8
+```
+
+
+```bash
+$ pgfortran -fast -Minfo=opt -o laplace laplace2d.f90 jacobi.f90
+```
+
+## Run Our Parallel Code on Multicore CPU
+
+In a future lab you will run parallelize the code to run on a multicore CPU. This is the simplest starting point, since it doesn't require us to think about copying our data between different memories. So that you can experience profiling with PGProf on a multicore CPU, a parallel version of the code has been provided. You will be able to parallelize the code yourself in the next lab.
+
+
+```bash
+$ pgfortran -fast -ta=multicore -Minfo=accel -o laplace_parallel ./solutions/parallel/laplace2d.f90 ./solutions/parallel/jacobi.f90 && ./laplace_parallel
+```
+
+### Compiling Multicore Code using PGI
+
+Again, you do not need to memorize the compiler commands to complete this lab. Though, if you want to use OpenACC with your own personal code, you will want to learn them.
+
+**-ta** : This flag will tell the compiler to compile our code for a specific parallel hardware. TA stands for *"Target Accelerator"*, an accelerator being any device that accelerates performance (in our case, this means parallel hardware.) Omitting the -ta flag will cause the code to compile sequentially.  
+**-ta=multicore** will tell the compiler to parallelize the code specifically for a multicore CPU.  
+**-Minfo** : This flag will tell the compiler to give us some feedback when compiling the code.  
+**-Minfo=accel** : will only give us feedback about the parallelization of our code.  
+**-Minfo=opt** : will give us feedback about sequential optimizations.  
+**-Minfo=all** : will give all feedback; this includes feedback about parallelizaton, sequential optimizations, and even parts of the code that couldn't be optimized for one reason or another.  
+
+If you would like to see the c_mcopy8 from earlier, try switching the Minfo flag with `-Minfo=accel,opt`.
+
+
+## Profiling Multicore Code
+
+We will use PGProf visual profiler this time to get a more graphical view of the profile. [Click here](/vnc) to open a new browser tab with a virtual desktop runnning the PGProf profiler. Normally you would open this program on your local machine by running the `pgprof` command or choosing it from your installed applications.
+
+After accessing the URL, the first screen will ask you to connect to VNC ![connect.png](../images/connect.png)
+You will be asked to enter the password. Please enter "nvidia" as the password ![password.png](../images/password.png)
+We have already run Visual Profiler for you and the first screen you see is to choose a workspace. You can keep the default workspace and press enter ![workspace.png](../images/workspace.png)
+
+We will start by profiling the laplace executable that we created earlier. To do this, Select File > New Session. After doing this you should see a pop-up like the one in the picture below.
+
+![pgprof1.png](../images/pgprof1.png) 
+
+Then where is says "File: Enter Executable File [required]", select "Browse". Then select File Systems > home > openacc > labs > module2 > English > Fortran.
+
+Select our "laplace" executable file. 
+
+![location.png](../images/location.png)
+
+Then select "Next", followed by "Finished". 
+
+![pgprof4.png](../images/pgprof4.PNG) 
+
+
+Follow the steps from earlier to profile the code with PGPROF, however, select the **`laplace_parallel`** executable this time instead of **`laplace`**. If you have closed the noVNC client, you can reopen it by <a href="/vnc" target="_blank">clicking this link</a>.
+
+This is the view that we are greeted with when profiling a multicore application.
+
+![pgprof_parallel1.PNG](../images/pgprof_parallel1.PNG)
+
+The first difference we see is the blue "timeline." This timeline represents when our program is executing something on the parallel hardware. This means that every call to `calcNext` and `swap` should be represented by a blue bar. 
+
+This is the main idea behind parallel programming. When you consider the **TOTAL** computation time, it will take almost equivalent time to our sequential program, however the application runtime decreases due to the fact that we can now execute portions of our code in parallel by spreading the work across multiple threads.
+
+## Conclusion
+
+Now we have a good understanding of how our program is running, and which parts of the program are time consuming. In the next lab, we will parallelize our program using OpenACC.
+
+We are working on a very simple code that is specifically used for teaching purposes. Meaning that, in terms of complexity, it can be fairly underwhelming. Profiling code will become exponentially more useful if you chose to work on a "real-world" code; a code with possibly hundreds of functions, or millions of lines of code. Profiling may seem trivial when we only have 4 functions, and our entire code is contained in only two files, however, profiling will be one of your greatest assets when parallelizing real-world code.
+
+## Bonus Task
+
+For right now, we are focusing on multicore CPUs. Eventually, we will transition to GPUs. If you are familiar with GPUs, and would like to play with a GPU profile, then feel free to try this bonus task. If you do not want to complete this task now, you will have an opportunity in later labs (where we will also explain more about what is happening.)
+
+Run this script to compile/run our code on a GPU.
+
+
+```bash
+$ pgfortran -fast -ta=tesla -Minfo=accel -o laplace_gpu ./solutions/gpu/laplace2d.f90 ./solutions/gpu/jacobi.f90 && ./laplace_gpu
+```
+
+Now, within PGPROF, select File > New Session. Follow the same steps as earlier, except select the **`laplace_gpu`** executable. If you close the noVNC window, you can reopen it by <a href="/vnc" target="_blank">clicking this link</a>.
+
+Happy profiling!
+
+## Post-Lab Summary
+
+If you would like to download this lab for later viewing, it is recommend you go to your browsers File menu (not the Jupyter notebook file menu) and save the complete web page.  This will ensure the images are copied down as well.
+
+You can also execute the following cell block to create a zip-file of the files you've been working on, and download it with the link below.
+
+
+```python
+%%bash
+rm -f openacc_files.zip
+zip -r openacc_files.zip ../C/* ../Fortran/*
+```
+
+**After** executing the above zip command, you should be able to download the zip file [here](files/openacc_files.zip)
+
+# Licensing
+This material is released by NVIDIA Corporation under the Creative Commons Attribution 4.0 International (CC BY 4.0).

--- a/labs/module2/README.md
+++ b/labs/module2/README.md
@@ -1,0 +1,13 @@
+Application Profiling with PGProf Lab
+=====================================
+
+This lab is meant to accompany Module 2 of the OpenACC.org teaching materials.
+The purpose of this lab is to introduce students to application profiling using
+the PGProf profiler. Lab instructions and source code is available for C/C++
+and Fortran.
+
+Please see the following files to begin the lab:
+
+* [C/C++](English/C/README.md)
+* [Fortran](English/Fortran/README.md)
+

--- a/labs/module3/English/C/README.md
+++ b/labs/module3/English/C/README.md
@@ -1,0 +1,389 @@
+# OpenACC Directives
+
+This version of the lab is intended for C/C++ programmers. The Fortran version of this lab is available [here](../Fortran/README.md).
+
+You will receive a warning five minutes before the lab instance shuts down. Remember to save your work! If you are about to run out of time, please see the [Post-Lab](#Post-Lab-Summary) section for saving this lab to view offline later.
+
+Don't forget to check out additional [OpenACC Resources](https://www.openacc.org/resources) and join our [OpenACC Slack Channel](https://www.openacc.org/community#slack) to share your experience and get more help from the community.
+
+---
+Let's execute the cell below to display information about the GPUs running on the server. To do this, execute the cell block below by giving it focus (clicking on it with your mouse), and hitting Ctrl-Enter, or pressing the play button in the toolbar above.  If all goes well, you should see some output returned below the grey cell.
+
+
+```bash
+$ pgaccelinfo
+```
+
+---
+
+## Introduction
+
+Our goal for this lab is to begin applying OpenACC directives to parallelize our code.
+  
+  
+  
+![development_cycle.png](../images/development_cycle.png)
+
+This is the OpenACC 3-Step development cycle.
+
+**Analyze** your code, and predict where potential parallelism can be uncovered. Use profiler to help understand what is happening in the code, and where parallelism may exist.
+
+**Parallelize** your code, starting with the most time consuming parts. Focus on maintaining correct results from your program.
+
+**Optimize** your code, focusing on maximizing performance. Performance may not increase all-at-once during early parallelization.
+
+We are currently tackling the **parallelize** step. We will include OpenACC directives to our Laplace Heat Distribution sample code, then run/profile our code on a multicore CPU.
+
+---
+
+## Run the Code
+
+Before we attempt to parallelize our code, let's run it sequentially, and see how it's performing. This will generate an executable called "laplace". This will be our sequential executable; we will name our parallel executable "laplace_parallel".
+
+
+```bash
+$ pgcc -fast -o laplace jacobi.c laplace2d.c && echo "Compilation Successful!" && ./laplace
+```
+
+### Optional: Analyze the Code
+
+If you would like a refresher on the code files that we are working on, you may view both of them using the two links below.
+
+[jacobi.c](../C/jacobi.c)  
+[laplace2d.c](../C/laplace2d.c)  
+
+### Optional: Profile the Code
+
+If you would like to profile the sequential code, you may select <a href="/vnc" target="_blank">this link.</a> When prompted for a password, type `openacc`. This will open a noVNC window, then you may use PGPROF to profile our sequential laplace code. The executable will be found in the `/home/openacc/labs/module3/English/C` directory.
+
+---
+
+## OpenACC Directives
+
+Using OpenACC directives will allow us to parallelize our code without needing to explicitly alter our code. What this means is that, by using OpenACC directives, we can have a single code that will function as both a sequential code and a parallel code.
+
+### OpenACC Syntax
+
+**#pragma acc &lt;directive> &lt;clauses>**
+
+**#pragma** in C/C++ is what's known as a "compiler hint." These are very similar to programmer comments, however, the compiler will actually read our pragmas. Pragmas are a way for the programmer to "guide" the compiler, without running the chance damaging the code. If the compiler does not understand the pragma, it can ignore it, rather than throw a syntax error.
+
+**acc** is an addition to our pragma. It specifies that this is an **OpenACC pragma**. Any non-OpenACC compiler will ignore this pragma. Even our PGI compiler can be told to ignore them. (which lets us run our parallel code sequentially!)
+
+**directives** are commands in OpenACC that will tell the compiler to do some action. For now, we will only use directives that allow the compiler to parallelize our code.
+
+**clauses** are additions/alterations to our directives. These include (but are not limited to) optimizations. The way that I prefer to think about it: directives describe a general action for our compiler to do (such as, paralellize our code), and clauses allow the programmer to be more specific (such as, how we specifically want the code to be parallelized).
+
+
+---
+### Parallel Directive
+
+There are three directives we will cover in this lab: parallel, kernels, and loop. Once we understand all three of them, you will be tasked with parallelizing our laplace code with your preferred directive (or use all of them, if you'd like!)
+
+The parallel directive may be the most straight-forward of the directives. It will mark a region of the code for parallelization (this usually only includes parallelizing a single **for** loop.) Let's take a look:
+
+```cpp
+#pragma acc parallel loop
+for (int i = 0; i < N; i++ )
+{
+    < loop code >
+}
+```
+
+We may also define a "parallel region". The parallel region may have multiple loops (though this is often not recommended!) The parallel region is everything contained within the outer-most curly braces.
+
+```cpp
+#pragma acc parallel
+{
+    #pragma acc loop
+    for (int i = 0; i < N; i++ )
+    {
+        < loop code >
+    }
+}
+```
+
+`#pragma acc parallel loop` will mark the next loop for parallelization. It is extremely important to include the **loop**, otherwise you will not be parallelizing the loop properly. The parallel directive tells the compiler to "redundantly parallelize" the code. The **loop** directive specifically tells the compiler that we want the loop parallelized. Let's look at an example of why the loop directive is so important.
+
+![parallel1](../images/parallel1.png)
+![parallel2](../images/parallel2.png)
+![parallel3](../images/parallel3.png)
+
+We are soon going to move onto the next directive (the kernels directive) which also allows us to parallelize our code. We will also mark the differences between this two directives. With that being said, the following information is completely unique to the parallel directive:
+
+The parallel directive leaves a lot of decisions up to the programmer. The programmer will decide what is, and isn't, parallelizable. The programmer will also have to provide all of the optimizations - the compiler assumes nothing. If any mistakes happen while parallelizing the code, it will be up to the programmer to identify them and correct them.
+
+We will soon see how the kernels directive is the exact opposite in all of these regards.
+
+### Optional: Parallelize our Code with the Parallel Directive
+
+It is recommended that you learn all three of the directives prior to altering the laplace code. However, if you wish to try out the parallel directive *now*, then you may use the following links to edit the laplace code.
+
+[jacobi.c](../C/jacobi.c)   
+[laplace2d.c](../C/laplace2d.c) 
+
+(be sure to save the changes you make by pressing ctrl+s)
+
+You may run your code by running the following script:
+
+
+```bash
+$ pgcc -fast -ta=multicore -Minfo=accel -o laplace_parallel jacobi.c laplace2d.c && ./laplace_parallel
+```
+
+---
+### Kernels Directive
+
+The kernels directive allows the programmer to step back, and rely solely on the compiler. Let's look at the syntax:
+
+```cpp
+#pragma acc kernels
+for (int i = 0; i < N; i++ )
+{
+    < loop code >
+}
+```
+
+Just like in the `parallel` directive example, we are parallelizing a single loop. Recall that when using the `parallel` directive, it must always be paired with the `loop` directive, otherwise the code will be improperly parallelized. The `kernels` directive does not follow the same rule, and in some compilers, adding the loop directive may limit the compilers ability to optimize the code.
+
+As said previously, the `kernels` directive is the exact opposite of the `parallel` directive. This means that the compiler is making a lot of assumptions, and may even override the programmers decision to parallelize code. Also, by default, the compiler will attempt to optimize the loop. The compiler is generally pretty good at optimizing loops, and sometimes may be able to optimize the loop in a way that the programmer cannot describe. However, usually, the programmer will be able to achieve better performance by optimizing the loop themself.
+
+If you run into a situation where the compiler refuses to parallelize a loop, you may override the compilers decision. (however, keep in mind that by overriding the compilers decision, you are taking responsibility for any mistakes the occur from parallelizing the code!) In this code segment, we are using the independent clause to ensure the compiler that we think the loop is parallelizable.
+
+```cpp
+#pragma acc kernels loop independent
+for (int i = 0; i < N; i++ )
+{
+    < loop code >
+}
+```
+
+One of the largest advantages of the `kernels` directive is its ability to parallelize many loops at once. For example, in the following code segment, we are able to effectively parallelize two loops at once by utilizing a kernels region (similar to a parallel region, that we saw earlier.)
+
+```cpp
+#pragma acc kernels
+{
+    for (int i = 0; i < N; i++ )
+    {
+        < loop code >
+    }
+    
+    < some other sequential code >
+    
+    for (int j = 0; j < M; j++ )
+    {
+        < loop code >
+    }
+}
+```
+
+By using the kernels directive, we can parallelize more than one loop (as many loops as we want, actually.) We are also able to include sequential code between the loops, without needing to include multiple directives. Similar to before, let's look at a visual example of how the kernels directive works.
+
+![kernels1](../images/kernels1.png)
+![kernels2](../images/kernels2.png)
+
+Before moving onto our last directive (the loop directive), let's recap what makes the parallel and kernels directive so functionally different.
+
+**The parallel directive** gives a lot of control to the programmer. The programmer decides what to parallelize, and how it will be parallelized. Any mistakes made by the parallelization is at the fault of the programmer. It is recommended to use a parallel directive for each loop you want to parallelize.
+
+**The kernels directive** leaves majority of the control to the compiler. The compiler will analyze the loops, and decide which ones to parallelize. It may refuse to parallelize certain loops, but the programmer can override this decision. You may use the kernels directive to parallelize large portions of code, and these portions may include multiple loops.
+
+### Optional: Parallelize our Code with the Kernels Directive
+
+It is recommended that you learn all three of the directives prior to altering the laplace code. However, if you wish to try out the kernels directive *now*, then you may use the following links to edit the laplace code. Pay close attention to the compiler feedback, and be prepared to add the *independent* clause to your loops.
+
+[jacobi.c](../C/jacobi.c)   
+[laplace2d.c](../C/laplace2d.c)  
+
+(be sure to save the changes you make by pressing ctrl+s)
+
+You may run your code by running the following script:
+
+
+```bash
+$ pgcc -fast -ta=multicore -Minfo=accel -o laplace_parallel jacobi.c laplace2d.c && ./laplace_parallel
+```
+
+---
+### Loop Directive
+
+We've seen the loop directive used and mentioned a few times now; it's time to formally define it. The loop directive has two major uses:
+* Mark a single loop for parallelization 
+* Allow us to explicitly define optimizations/alterations for the loop
+
+The loop optimizations are a subject for another lab, so for now, we will focus on the parallelization aspect. For the loop directive to work properly, it must be contained within either the parallel or kernels directive.
+
+For example:
+
+```cpp
+#pragma acc parallel loop
+for (int i = 0; i < N; i++ )
+{
+    < loop code >
+}
+```
+
+or 
+
+```cpp
+#pragma acc kernels
+{
+    #pragma acc loop independent
+    for (int i = 0; i < N; i++ )
+    {
+        < loop code >
+    }
+}
+```
+
+When using the `parallel` directive, you must include the loop directive for the code to function properly. When using the `kernels` directive, the loop directive is implied, and does not need to be included.
+
+We may also use the loop directive to parallelize multi-dimensional loop nests. Depending on the parallel hardware you are using, you may not be able to achieve multi-loop parallelism. Some parallel hardware is simply limited in its parallel capability, and thus parallelizing inner loops does not offer any extra performance (though is also does not hurt the program, either.) In this lab, we are using a multicore CPU as our parallel hardware, and thus, multi-loop parallelization isn't entirely possible. However, when using GPUs (which we will in the next lab!) we can utilize multi-loop parallelism.
+
+Either way, this is what multi-loop parallelism looks like:
+
+```cpp
+#pragma acc parallel loop
+for (int i = 0; i < N; i++ )
+{
+    #pragma acc loop
+    for( int j = 0; j < M; j++ )
+    {
+        < loop code >
+    }
+}
+```
+
+The kernels directive is also very good at parallelizing nested loops. We can recreate the same code above with the kernels directive:
+
+```cpp
+#pragma acc kernels
+for (int i = 0; i < N; i++ )
+{
+    for( int j = 0; j < M; j++ )
+    {
+        < loop code >
+    }
+}
+```
+
+Notice that just like before, we do not need to include the loop directive.
+
+## Parallelizing Our Laplace Code
+
+Using your knowledge about the parallel, kernels, and loop directive, add OpenACC directives to our laplace code and parallelize it. You may edit the code by selecting the following links:  
+
+[jacobi.c](../C/jacobi.c)   
+[laplace2d.c](../C/laplace2d.c)  
+
+(be sure to save the changes you make by pressing ctrl+s)
+
+
+---
+To compile and run your parallel code on a multicore CPU, run the following script:
+
+
+```bash
+$ pgcc -fast -ta=multicore -Minfo=accel -o laplace_parallel jacobi.c laplace2d.c && ./laplace_parallel
+```
+
+---
+
+If at any point you feel that you have made a mistake, and would like to reset the code to how it was originally, you may run the following script:
+
+
+```bash
+$ cp ./solutions/sequential/jacobi.c ./jacobi.c && cp ./solutions/sequential/laplace2d.c ./laplace2d.c && echo "Reset Complete"
+```
+
+---
+
+If at any point you would like to re-run the sequential code to check results/performance, you may run the following script:
+
+
+```bash
+$ cd solutions/sequential && pgcc -fast -o laplace_seq jacobi.c laplace2d.c && ./laplace_seq
+```
+
+---
+
+If you would like to view information about the CPU we are running on, you may run the following script:
+
+
+```bash
+$ pgcpuid
+```
+
+### Optional: Compiling Multicore Code
+
+Knowing how to compile multicore code is not needed for the completion of this lab. However, it will be useful if you want to parallelize your own personal code later on.
+
+**-Minfo** : This flag will give us feedback from the compiler about code optimizations and restrictions.  
+**-Minfo=accel** will only give us feedback regarding our OpenACC parallelizations/optimizations.  
+**-Minfo=all** will give us all possible feedback, including our parallelizaiton/optimizations, sequential code optimizations, and sequential code restrictions.  
+**-ta** : This flag allows us to compile our code for a specific target parallel hardware. Without this flag, the code will be compiled for sequential execution.  
+**-ta=multicore** will allow us to compiler our code for a multicore CPU.  
+
+### Optional: Profiling Multicore Code
+
+If you would like to profile your multicore code with PGPROF, click <a href="/vnc" target="_blank">this link.</a> The **laplace_parallel** executable will be found in /notebooks/C.
+
+---
+
+## Conclusion
+
+If you would like to check your results, run the following script.
+
+
+```bash
+$ cd solutions/multicore && pgcc -fast -ta=multicore -Minfo=accel -o laplace_parallel jacobi.c laplace2d.c && ./laplace_parallel
+```
+
+If you would like to view the solution codes, you may use the following links.
+
+**Using the Parallel Directive**  
+[jacobi.c](../C/solutions/multicore/jacobi.c)  
+[laplace2d.c](../C/solutions/multicore/laplace2d.c)  
+
+**Using the Kernels Directive**  
+[jacobi.c](../C/solutions/multicore/kernels/jacobi.c)  
+[laplace2d.c](../C/solutions/multicore/kernels/laplace2d.c)  
+
+We are able to parallelize our code for a handful of different hardware by using either the **parallel** or **kernels** directive. We are also able to define additional levels of parallelism by using the **loop** directive inside the parallel/kernels directive. You may also use these directives to parallelize nested loops. 
+
+There are a few optimizations that we could make to our code at this point, but, for the most part, our multicore code will not get much faster. In the next lab, we will shift our attention to programming for a GPU accelerator, and while learning about GPUs, we will touch on how to handle memory management in OpenACC.
+
+---
+
+## Bonus Task
+
+1. If you chose to use only one of the directives (either parallel or kernels), then go back and use the other one. Compare the runtime of the two versions, and profile both.
+
+2. If you would like some additional lessons on using OpenACC to parallelize our code, there is an Introduction to OpenACC video series available from the OpenACC YouTube page. The first two videos in the series covers a lot of the content that was covered in this lab.  
+[Introduction to Parallel Programming with OpenACC - Part 1](https://youtu.be/PxmvTsrCTZg)  
+[Introduction to Parallel Programming with OpenACC - Part 2](https://youtu.be/xSCD4-GV41M)
+
+3. As discussed earlier, a multicore accelerator is only able to take advantage of one level of parallelism. However, a GPU can take advantage of more. Make sure to use the skills you learned in the **Loop Directive** section of the lab, and parallelize the multi-dimensional loops in our code. Then run the script below to run the code on a GPU. Compare the results (including compiler feedback) to our multicore implementation.
+
+
+```bash
+$ pgcc -fast -ta=tesla:managed -Minfo=accel -o laplace_gpu jacobi.c laplace2d.c && ./laplace_gpu
+```
+
+## Post-Lab Summary
+
+If you would like to download this lab for later viewing, it is recommend you go to your browsers File menu (not the Jupyter notebook file menu) and save the complete web page.  This will ensure the images are copied down as well.
+
+You can also execute the following cell block to create a zip-file of the files you've been working on, and download it with the link below.
+
+
+```python
+%%bash
+rm -f openacc_files.zip
+zip -r openacc_files.zip *
+```
+
+**After** executing the above zip command, you should be able to download the zip file [here](files/openacc_files.zip)
+
+# Licensing
+This material is released by NVIDIA Corporation under the Creative Commons Attribution 4.0 International (CC BY 4.0).

--- a/labs/module3/English/Fortran/README.md
+++ b/labs/module3/English/Fortran/README.md
@@ -1,0 +1,376 @@
+# OpenACC Directives
+
+This version of the lab is intended for Fortran programmers. The C/C++ version of this lab is available [here](../C/README.md).
+
+The following timer counts down to a five minute warning before the lab instance shuts down.  You should get a pop up at the five minute warning reminding you to save your work!  If you are about to run out of time, please see the [Post-Lab](#Post-Lab-Summary) section for saving this lab to view offline later. This is the Fortran version of this lab, for the C version [click here](../C/README.md).
+
+Don't forget to check out additional [OpenACC Resources](https://www.openacc.org/resources) and join our [OpenACC Slack Channel](https://www.openacc.org/community#slack) to share your experience and get more help from the community.
+
+---
+Let's execute the cell below to display information about the GPUs running on the server. To do this, execute the cell block below by giving it focus (clicking on it with your mouse), and hitting Ctrl-Enter, or pressing the play button in the toolbar above.  If all goes well, you should see some output returned below the grey cell.
+
+
+```bash
+$ pgaccelinfo
+```
+
+---
+
+## Introduction
+
+Our goal for this lab is to learn what exactly code profiling is, and how we can use it to help us write powerful parallel programs.  
+  
+  
+  
+![development_cycle.png](../images/development_cycle.png)
+
+This is the OpenACC 3-Step development cycle.
+
+**Analyze** your code, and predict where potential parallelism can be uncovered. Use profiler to help understand what is happening in the code, and where parallelism may exist.
+
+**Parallelize** your code, starting with the most time consuming parts. Focus on maintaining correct results from your program.
+
+**Optimize** your code, focusing on maximizing performance. Performance may not increase all-at-once during early parallelization.
+
+We are currently tackling the **analyze** step. We will use PGI's code profiler to get an understanding of a relatively simple sample code before moving onto the next two steps.
+
+## Run the Code
+
+Our first step to analyzing this code is to run it. We need to record the results of our program before making any changes so that we can compare them to the results from the parallel code later on. It is also important to record the time that the program takes to run, as this will be our primary indicator to whether or not our parallelization is improving performance.
+
+
+```bash
+$ pgfortran -fast -o laplace laplace2d.f90 jacobi.f90 && echo "Compilation Successful!" && ./laplace
+```
+
+### Optional: Analyze the Code
+
+If you would like a refresher on the code files that we are working on, you may view both of them using the two links below.
+
+[jacobi.f90](../Fortran/jacobi.f90)  
+[laplace2d.f90](../Fortran/laplace2d.f90)  
+
+### Optional: Profile the Code
+
+If you would like to profile the sequential code, you may select <a href="/vnc" target="_blank">this link.</a> When prompted for a password, type `openacc`. This will open a noVNC window, then you may use PGPROF to profile our sequential laplace code. The executable will be found in the `/home/openacc/labs/module3/English/Fortran` directory.
+
+---
+
+## OpenACC Directives
+
+Using OpenACC directives will allow us to parallelize our code without needing to explicitly alter our code. What this means is that, by using OpenACC directives, we can have a single code that will function as both a sequential code and a parallel code.
+
+### OpenACC Syntax
+
+`!$acc <directive> <clauses>`
+
+`!$acc` in Fortran is what's known as a "compiler directive." These are very similar to programmer comments, since the line begins with a comment statement `!`. After the comment is `$acc`. OpenACC compliant compilers with appropriate command line options can interpret this as an OpenACC directive that "guide" the compiler, without running the chance of damaging the code. If the compiler does not understand `!$acc` it can ignore it, rather than throw a syntax error because it's just a comment.
+
+**directives** are instructions in OpenACC that will tell the compiler to do some action. For now, we will only use directives that allow the compiler to parallelize our code.
+
+**clauses** are additions/alterations to our directives. These include (but are not limited to) optimizations. The way that I prefer to think about it: directives describe a general action for our compiler to do (such as, paralellize our code), and clauses allow the programmer to be more specific (such as, how we specifically want the code to be parallelized).
+
+
+---
+### Parallel Directive
+
+There are three directives we will cover in this lab: parallel, kernels, and loop. Once we understand all three of them, you will be tasked with parallelizing our laplace code with your preferred directive (or use all of them, if you'd like!)
+
+The parallel directive may be the most straight-forward of the directives. It will mark a region of the code for parallelization (this usually only includes parallelizing a single for loop.) Let's take a look:
+
+```fortran
+    !$acc parallel loop
+    do i=1,N
+        < loop code >
+    enddo
+```
+
+We may also define a "parallel region". The parallel region may have multiple loops (though this is often not recommended!) The parallel region is everything contained within the outer-most loop.
+
+```fortran
+!$acc parallel
+    !$acc loop
+    do i=1,N
+        < loop code >
+    enddo
+
+```
+
+`!$acc parallel loop` will mark the next loop for parallelization. It is extremely important to include the **`loop`**, otherwise you will not be parallelizing the loop properly. The parallel directive tells the compiler to "redundantly parallelize" the code. The `loop` directive specifically tells the compiler that we want the loop parallelized. Let's look at an example of why the loop directive is so important.
+
+![parallel1](../images/parallel1f.png)
+![parallel2](../images/parallel2f.png)
+![parallel3](../images/parallel3f.png)
+
+We are soon going to move onto the next directive (the kernels directive) which also allows us to parallelize our code. We will also mark the differences between this two directives. With that being said, the following information is completely unique to the parallel directive:
+
+The parallel directive leaves a lot of decisions up to the programmer. The programmer will decide what is, and isn't, parallelizable. The programmer will also have to provide all of the optimizations - the compiler assumes nothing. If any mistakes happen while parallelizing the code, it will be up to the programmer to identify them and correct them.
+
+We will soon see how the kernels directive is the exact opposite in all of these regards.
+
+### Optional: Parallelize our Code with the Parallel Directive
+
+It is recommended that you learn all three of the directives prior to altering the laplace code. However, if you wish to try out the parallel directive *now*, then you may use the following links to edit the laplace code.
+
+[jacobi.f90](../Fortran/jacobi.f90)   
+[laplace2d.f90](../Fortran/laplace2d.f90)  
+
+(be sure to save the changes you make by pressing ctrl+s)
+
+You may run your code by running the following script:
+
+
+```bash
+$ pgfortran -fast -ta=multicore -Minfo=accel -o laplace_parallel laplace2d.f90 jacobi.f90 && ./laplace_parallel
+```
+
+---
+### Kernels Directive
+
+The kernels directive allows the programmer to step back, and rely solely on the compiler. Let's look at the syntax:
+
+```fortran
+!$acc kernels
+do i=1,N
+    < loop code >
+enddo
+!acc end kernels
+```
+
+Just like in the parallel directive example, we are parallelizing a single loop. Recall that when using the parallel directive, it must always be paired with the loop directive, otherwise the code will be improperly parallelized. The kernels directive does not follow the same rule, and in some compilers, adding the loop directive may limit the compilers ability to optimize the code.
+
+In this case you also need to include the statement "!acc end kernels" so the compiler knows the "scope" of the directive.
+
+As said previously, the kernels directive is the exact opposite of the parallel directive. This means that the compiler is making a lot of assumptions, and may even override the programmers decision to parallelize code. Also, by default, the compiler will attempt to optimize the loop. The compiler is generally pretty good at optimizing loops, and sometimes may be able to optimize the loop in a way that the programmer cannot describe. However, usually, the programmer will be able to achieve better performance by optimizing the loop themself.
+
+If you run into a situation where the compiler refuses to parallelize a loop, you may override the compilers decision. (however, keep in mind that by overriding the compilers decision, you are taking responsibility for any mistakes the occur from parallelizing the code!) In this code segment, we are using the independent clause to ensure the compiler that we think the loop is parallelizable.
+
+```fortran
+!$acc kernels loop independent
+do i=1,N
+    < loop code >
+enddo
+!$acc end kernels
+```
+
+One of the largest advantages of the kernels directive is its ability to parallelize many loops at once. For example, in the following code segment, we are able to effectively parallelize two loops at once by utilizing a kernels region (similar to a parallel region, that we saw earlier.) This is done by putting the statement "!acc end kernels" at the end of the directive region.
+
+```fortran
+!$acc kernels
+do i=1,N
+   < loop code >
+enddo
+    
+< some other sequential code >
+    
+do j=1,M
+   < loop code >
+enddo
+!$acc end kernels
+```
+
+By using the kernels directive, we can parallelize more than one loop (as many loops as we want, actually.) We are also able to include sequential code between the loops, without needing to include multiple directives. Similar to before, let's look at a visual example of how the kernels directive works.
+
+![kernels1](../images/kernels1f.png)
+![kernels2](../images/kernels2f.png)
+
+Before moving onto our last directive (the loop directive), let's recap what makes the parallel and kernels directive so functionally different.
+
+**The parallel directive** gives a lot of control to the programmer. The programmer decides what to parallelize, and how it will be parallelized. Any mistakes made by the parallelization is at the fault of the programmer. It is recommended to use a parallel directive for each loop you want to parallelize.
+
+**The kernels directive** leaves majority of the control to the compiler. The compiler will analyze the loops, and decide which ones to parallelize. It may refuse to parallelize certain loops, but the programmer can override this decision. You may use the kernels directive to parallelize large portions of code, and these portions may include multiple loops.
+
+
+### Optional: Parallelize our Code with the Kernels Directive
+
+It is recommended that you learn all three of the directives prior to altering the laplace code. However, if you wish to try out the kernels directive *now*, then you may use the following links to edit the laplace code. Pay close attention to the compiler feedback, and be prepared to add the *independent* clause to your loops.
+
+[jacobi.f90](../Fortran/jacobi.f90)   
+[laplace2d.f90](../Fortran/laplace2d.f90)  
+
+(be sure to save the changes you make by pressing ctrl+s)
+
+You may run your code by running the following script:
+
+
+```bash
+$ pgfortran -fast -ta=multicore -Minfo=accel -o laplace_parallel laplace2d.f90 jacobi.f90 && ./laplace_parallel
+```
+
+---
+### Loop Directive
+
+We've seen the `loop` directive used and mentioned a few times now; it's time to formally define it. The `loop` directive has two major uses:
+* Mark a single loop for parallelization 
+* Allow us to explicitly define optimizations/alterations for the loop
+
+The loop optimizations are a subject for another lab, so for now, we will focus on the parallelization aspect. For the `loop` directive to work properly, it must be contained within either the parallel or kernels directive.
+
+For example:
+
+```fortran
+!$acc parallel loop
+do i=1,N
+    < loop code >
+enddo
+```
+
+or 
+
+```fortran
+!$acc kernels
+do i=1,N
+   < loop code >
+enddo
+!$acc end kernels
+```
+
+When using the `parallel` directive, you must include the loop directive for the code to function properly. When using the `kernels` directive, the loop directive is implied, and does not need to be included.
+
+We may also use the loop directive to parallelize multi-dimensional loop nests. Depending on the parallel hardware you are using, you may not be able to achieve multi-loop parallelism. Some parallel hardware is simply limited in its parallel capability, and thus parallelizing inner loops does not offer any extra performance (though is also does not hurt the program, either.) In this lab, we are using a multicore CPU as our parallel hardware, and thus, multi-loop parallelization isn't entirely possible. However, when using GPUs (which we will in the next lab!) we can utilize multi-loop parallelism.
+
+Either way, this is what multi-loop parallelism looks like:
+
+```fortran
+!$acc parallel loop
+do i=1,N
+    !acc loop
+    do j=1,M
+        < loop code >
+    enddo
+enddo
+```
+
+The `kernels` directive is also very good at parallelizing nested loops. We can recreate the same code above with the `kernels` directive:
+
+```fortran
+!$acc kernels
+do i=1,N
+   do j=1,M
+        < loop code >
+    enddo
+enddo
+!acc end kernels
+```
+
+Notice that just like before, we do not need to include the `loop` directive.
+
+
+## Parallelizing Our Laplace Code
+
+Using your knowledge about the parallel, kernels, and loop directive, add OpenACC directives to our laplace code and parallelize it. You may edit the code by selecting the following links:  
+
+[jacobi.f90](../../../../edit/module3/English/Fortran/jacobi.f90)   
+[laplace2d.f90](../../../../edit/module3/English/Fortran/laplace2d.f90)  
+
+(be sure to save the changes you make by pressing ctrl+s)
+
+
+---
+To compile and run your parallel code on a multicore CPU, run the following script:
+
+
+```bash
+$ pgfortran -fast -ta=multicore -Minfo=accel -o laplace_parallel laplace2d.f90 jacobi.f90 && ./laplace_parallel
+```
+
+---
+
+If at any point you feel that you have made a mistake, and would like to reset the code to how it was originally, you may run the following script:
+
+
+```bash
+$ cp ./solutions/sequential/jacobi.f90 ./jacobi.f90 && cp ./solutions/sequential/laplace2d.f90 ./laplace2d.f90 && echo "Reset Complete"
+```
+
+---
+
+If at any point you would like to re-run the sequential code to check results/performance, you may run the following script:
+
+
+```bash
+$ cd solutions/sequential && pgfortran -fast -o laplace_seq laplace2d.f90 jacobi.f90 && ./laplace_seq
+```
+
+---
+
+If you would like to view information about the CPU we are running on, you may run the following script:
+
+
+```bash
+$ pgcpuid
+```
+
+### Optional: Compiling Multicore Code
+
+Knowing how to compile multicore code is not needed for the completion of this lab. However, it will be useful if you want to parallelize your own personal code later on.
+
+**-Minfo** : This flag will give us feedback from the compiler about code optimizations and restrictions.  
+**-Minfo=accel** will only give us feedback regarding our OpenACC parallelizations/optimizations.  
+**-Minfo=all** will give us all possible feedback, including our parallelizaiton/optimizations, sequential code optimizations, and sequential code restrictions.  
+**-ta** : This flag allows us to compile our code for a specific target parallel hardware. Without this flag, the code will be compiled for sequential execution.  
+**-ta=multicore** will allow us to compiler our code for a multicore CPU.  
+
+### Optional: Profiling Multicore Code
+
+If you would like to profile your multicore code with PGPROF, click <a href="/vnc" target="_blank">this link.</a> The **laplace_parallel** executable will be found in /notebooks/Fortran.
+
+---
+
+## Conclusion
+
+If you would like to check your results, run the following script.
+
+
+```bash
+$ cd solutions/multicore && pgfortran -fast -ta=multicore -Minfo=accel -o laplace_parallel laplace2d.f90 jacobi.f90 && ./laplace_parallel
+```
+
+If you would like to view the solution codes, you may use the following links.
+
+**Using the Parallel Directive**  
+[jacobi.f90](../../../../edit/module3/English/Fortran/solutions/multicore/jacobi.f90)  
+[laplace2d.f90](../../../../edit/module3/English/Fortran/solutions/multicore/laplace2d.f90)  
+
+**Using the Kernels Directive**  
+[jacobi.f90](../../../../edit/module3/English/Fortran/solutions/multicore/kernels/jacobi.f90)  
+[laplace2d.f90](../../../../edit/module3/English/Fortran/solutions/multicore/kernels/laplace2d.f90)  
+
+We are able to parallelize our code for a handful of different hardware by using either the `parallel` or `kernels` directive. We are also able to define additional levels of parallelism by using the `loop` directive inside the parallel/kernels directive. You may also use these directives to parallelize nested loops. 
+
+There are a few optimizations that we could make to our code at this point, but, for the most part, our multicore code will not get much faster. In the next lab, we will shift our attention to programming for a GPU accelerator, and while learning about GPUs, we will touch on how to handle memory management in OpenACC.
+
+---
+
+## Bonus Task
+
+1. If you chose to use only one of the directives (either parallel or kernels), then go back and use the other one. Compare the runtime of the two versions, and profile both.
+
+2. If you would like some additional lessons on using OpenACC to parallelize our code, there is an Introduction to OpenACC video series available from the OpenACC YouTube page. The first two videos in the series covers a lot of the content that was covered in this lab.  
+[Introduction to Parallel Programming with OpenACC - Part 1](https://youtu.be/PxmvTsrCTZg)  
+[Introduction to Parallel Programming with OpenACC - Part 2](https://youtu.be/xSCD4-GV41M)
+
+3. As discussed earlier, a multicore accelerator is only able to take advantage of one level of parallelism. However, a GPU can take advantage of more. Make sure to use the skills you learned in the **Loop Directive** section of the lab, and parallelize the multi-dimensional loops in our code. Then run the script below to run the code on a GPU. Compare the results (including compiler feedback) to our multicore implementation.
+
+
+```bash
+$ pgfortran -fast -ta=tesla:managed -Minfo=accel -o laplace_gpu laplace2d.f90 jacobi.f90 && ./laplace_gpu
+```
+
+## Post-Lab Summary
+
+If you would like to download this lab for later viewing, it is recommend you go to your browsers File menu (not the Jupyter notebook file menu) and save the complete web page.  This will ensure the images are copied down as well.
+
+You can also execute the following cell block to create a zip-file of the files you've been working on, and download it with the link below.
+
+
+```python
+%%bash
+rm -f openacc_files.zip
+zip -r openacc_files.zip *
+```
+
+**After** executing the above zip command, you should be able to download the zip file [here](files/openacc_files.zip)
+
+# Licensing
+This material is released by NVIDIA Corporation under the Creative Commons Attribution 4.0 International (CC BY 4.0).

--- a/labs/module3/README.md
+++ b/labs/module3/README.md
@@ -1,0 +1,12 @@
+OpenACC Directives Basics
+=========================
+
+This lab is meant to accompany Module 3 of the OpenACC.org teaching
+materials. The purpose of this lab is to introduce OpenACC directives. Lab
+instructions and source code is available for C/C++ and Fortran.
+
+Please see the following files to begin the lab:
+
+* [C/C++](English/C/README.md)
+* [Fortran](English/Fortran/README.md)
+

--- a/labs/module4/English/C/README.md
+++ b/labs/module4/English/C/README.md
@@ -1,0 +1,327 @@
+# GPU Programming With OpenACC
+
+This version of the lab is intended for C/C++ programmers. The Fortran version of this lab is available [here](../Fortran/README.md).
+
+You will receive a warning five minutes before the lab instance shuts down. Remember to save your work! If you are about to run out of time, please see the [Post-Lab](#Post-Lab-Summary) section for saving this lab to view offline later.
+
+Don't forget to check out additional [OpenACC Resources](https://www.openacc.org/resources) and join our [OpenACC Slack Channel](https://www.openacc.org/community#slack) to share your experience and get more help from the community.
+
+---
+Let's execute the cell below to display information about the GPUs running on the server.  To do this, execute the cell block below by giving it focus (clicking on it with your mouse), and hitting Ctrl-Enter, or pressing the play button in the toolbar above.  If all goes well, you should see some output returned below the grey cell.
+
+
+```bash
+$ pgaccelinfo
+```
+
+---
+
+## Introduction
+
+Our goal for this lab is to learn how to run our code on a GPU (Graphical Processing Unit).
+  
+  
+  
+![development_cycle.png](../images/development_cycle.png)
+
+This is the OpenACC 3-Step development cycle.
+
+**Analyze** your code, and predict where potential parallelism can be uncovered. Use profiler to help understand what is happening in the code, and where parallelism may exist.
+
+**Parallelize** your code, starting with the most time consuming parts. Focus on maintaining correct results from your program.
+
+**Optimize** your code, focusing on maximizing performance. Performance may not increase all-at-once during early parallelization.
+
+We are currently tackling the **parallelize** step. We have parallelized our code for a multicore CPU, and now we will learn what we need to do to get it running on a GPU.
+
+---
+
+## Run the Code (Multicore)
+
+We have already completed a basic multicore implementation of our lab code. Run the following script IF you would prefer to use the parallel directive.
+
+
+```bash
+$ cp ./solutions/multicore/laplace2d.c ./laplace2d.c
+```
+
+---
+If you would prefer to use the kernels directive, run the following script.
+
+
+```bash
+$ cp ./solutions/multicore/kernels/laplace2d.c ./laplace2d.c
+```
+
+---
+Then you may run the multicore code by running the following script. An executable called **laplace_multicore** will be created.
+
+
+```bash
+$ pgcc -fast -ta=multicore -Minfo=accel -o laplace_multicore jacobi.c laplace2d.c && ./laplace_multicore
+```
+
+### Optional: Analyze the Code
+
+If you would like a refresher on the code files that we are working on, you may view both of them using the two links below.
+
+[jacobi.c](../../../../edit/module4/English/C/jacobi.c)  
+[laplace2d.c](../../../../edit/module4/English/C/laplace2d.c)  
+
+### Optional: Profile the Code
+
+If you would like to profile the multicore code, you may select <a href="/vnc" target="_blank">this link.</a> When prompted for a password, type `openacc`. This will open a noVNC window, then you may use PGPROF to profile our sequential laplace code. The executable will be found in the `/home/openacc/labs/module4/English/C` directory.
+
+---
+## Optional: Introduction to GPUs (Graphical Processing Units)
+
+GPUs were originally used to render computer graphics for video games. While they continue to dominate the video game hardware market, GPUs have also been adapted as a **high-throughput parallel hardware**. They excel at doing many things simultaneously.
+
+![cpu_with_gpu.png](../images/cpu_with_gpu.png)
+
+Similar to a multicore CPU, a GPU has multiple computational cores. A GPU will have many more cores, but these cores perform very badly when executing sequential serial code. Our goal when using a GPU is to only use it to offload our parallel code. All of our sequential code will continue to run on our CPU.
+
+GPUs are what is known as a SIMD architecture (SIMD stands for: single instruction, multiple data). This means that GPUs excel at taking a single computer instruction (such as a mathematical instruction, or a memory read/write) and applying that instruction to a large amount of data. Ultimately, this means that a GPU can execute thousands of operations at the same time. This function is very similar to our multicore CPU architecture, except that with a GPU, we have a many more cores at our disposal.
+
+![cpu_and_gpu_diagram.png](../images/cpu_and_gpu_diagram.png)
+
+This diagram represents a machine that contains a CPU and a GPU. We can see that the CPU and GPU are two complete seperate devices, connected via an I/O Bus. This bus is traditionally a PCI-e bus, however, NVLink is a newer, faster alternative. These two devices also have seperate memory. This means that during the execution of our program, some amount of data will be transferred between the CPU and the GPU.
+
+---
+## Data Management With OpenACC
+
+When programming for a GPU (or similar architecture), we must handle data management between the CPU and the GPU. The programmer is able to explicitly define data management by using the OpenACC **data directive and data clauses**. Otherwise, we are able to allow the copmpiler to handle all data management. Depending on the GPU (specifically older GPUs), allowing the compiler to handle data management might not be a viable option.
+
+### Using OpenACC Data Clauses
+
+Data clauses allow the programmer to specify data transfers between the host and device (or in our case, the CPU and the GPU). Let's look at an example where we do not use a data clause.
+
+```cpp
+int *A = (int*) malloc(N * sizeof(int));
+
+#pragma acc parallel loop
+for( int i = 0; i < N; i++ )
+{
+    A[i] = 0;
+}
+```
+
+We have allocated an array `A` outside of our parallel region. This means that `A` is allocated in the CPU memory. However, we access `A` inside of our loop, and that loop is contained within a `parallel` region. Within that parallel region, `A[i]` is attempting to access a memory location within the GPU memory. We didn't explicitly allocate `A` on the GPU, so one of two things will happen.
+
+1. The compiler will understand what we are trying to do, and automatically copy **A** from the CPU to the GPU.
+2. The program will check for an array **A** in GPU memory, it won't find it, and it will throw an error.
+
+Instead of hoping that we have a compiler that can figure this out, we could instead use a **data clause**.
+
+```cpp
+int *A = (int*) malloc(N * sizeof(int));
+
+#pragma acc parallel loop copy(A[0:N])
+for( int i = 0; i < N; i++ )
+{
+    A[i] = 0;
+}
+```
+
+We will learn the `copy` data clause first, because it is the easiest to use. With the inclusion of the `copy` data clause, our program will now copy the content of `A` from the CPU memory, into GPU memory. Then, during the execution of the loop, it will properly access `A` from the GPU memory. After the parallel region is finished, our program will copy `A` from the GPU memory back to the CPU memory. Let's look at one more direct example.
+
+```cpp
+int *A = (int*) malloc(N * sizeof(int));
+
+for( int i = 0; i < N; i++ )
+{
+    A[i] = 0;
+}
+
+#pragma acc parallel loop copy(A[0:N])
+for( int i = 0; i < N; i++ )
+{
+    A[i] = 1;
+}
+```
+
+Now we have two loops; the first loop will execute on the CPU (since it does not have an OpenACC parallel directive), and the second loop will execute on the GPU. Array `A` will be allocated on the CPU, and then the first loop will execute. This loop will set the contents of `A` to be all 0. Then the second loop is encountered; the program will copy the array `A` (which is full of 0's) into GPU memory. Then, we will execute the second loop on the GPU. This will edit the GPU's copy of `A` to be full of 1's.
+
+At this point, we have two seperate copies of `A`. The CPU copy is full of 0's, and the GPU copy is full of 1's. Now, after the parallel region finishes, the program will copy `A` back from the GPU to the CPU. After this copy, both the CPU and the GPU will contain a copy of `A` that contains all 1's. The GPU copy of `A` will then be deallocated.
+
+This image offers another step-by-step example of using the copy clause.
+
+![copy_step_by_step](../images/copy_step_by_step.png)
+
+We are also able to copy multiple arrays at once by using the following syntax.
+
+```cpp
+#pragma acc parallel loop copy(A[0:N], B[0:N])
+for( int i = 0; i < N; i++ )
+{
+    A[i] = B[i];
+}
+```
+
+### Array Shaping
+
+The shape of the array specifies how much data needs to be transferred. Let's look at an example:
+
+```cpp
+#pragma acc parallel loop copy(A[0:N])
+for( int i = 0; i < N; i++ )
+{
+    A[i] = 0;
+}
+```
+
+Focusing specifically on the `copy(A[0:N])`, the shape of the array is defined within the brackets. The syntax for array shape is **[starting_index:size]**. This means that (in the code example) we are copying data from array `A`, starting at index 0 (the start of the array), and copying N elements (which is most likely the length of the entire array).
+
+We are also able to only copy a portion of the array:
+
+```cpp
+#pragma acc parallel loop copy(A[1:N-2])
+```
+
+This would copy all of the elements of **A** except for the first, and last element.
+
+Lastly, if you do not specify a starting index, 0 is assumed. This means that
+
+```cpp
+#pragma acc parallel loop copy(A[0:N])
+```
+
+is equivalent to
+
+```cpp
+#pragma acc parallel loop copy(A[:N])
+```
+
+### Including Data Clauses in our Laplace Code
+
+Add `copy` data clause to our laplace code by selecting the following links:
+
+[jacobi.c](../../../../edit/module4/English/C/jacobi.c)  
+[laplace2d.c](../../../../edit/module4/English/C/laplace2d.c)  
+
+Then, when you are ready, you may run the code by running the following script. It may not be intuitively obvious yet, but we are expecting the code to perform very poorly. For this reason, we are running our GPU code on a **significantly smaller input size**. If you were to run the GPU code on the full sized input, it will take several minutes to run.
+
+
+```bash
+$ pgcc -fast -ta=tesla -Minfo=accel -o laplace_data_clauses jacobi.c laplace2d.c && ./laplace_data_clauses 1024 1024
+```
+
+If you are unsure about your answer, you can view the solution [here.](../../../../edit/module4/English/C/solutions/basic_data/laplace2d.c)
+
+### Optional: Compiling GPU Code
+
+Different GPUs will need to be compiled in slightly different ways. To get information about our GPU, we can use the **pgaccelinfo** command.
+
+
+```bash
+$ pgaccelinfo
+```
+
+There is a lot of information contained here, however, we are only going to focus on two points.
+
+**Managed Memory:** will tell us whether or not our GPU supports CUDA managed memory. We will cover managed memory a little bit later in the lab.
+
+**PGI Compiler Option:** tells us which target to compiler for. Ealier we were using a `-ta=multicore` flag for our multicore code. Now, to compile for our specific GPU, we will replace it with `-ta=tesla`.
+
+---
+### Profiling GPU Code
+
+In order to understand why our program is performing so poorly, we should consult our profiler.
+
+To profile our code, select <a href="/vnc" target="_blank">this link.</a> This will open a noVNC window, then you will use PGPROF to profile our edited laplace code. If prompted for a password, type `openacc`.
+
+To open a new profiling session, select File > New Session. You will be greeted with this window.
+
+![pgprof1.PNG](../images/pgprof1.PNG)
+
+Where it says "File: Enter executable file [required]", select Browse. Select File System > notebooks, then press OK.
+
+![pgprof2.PNG](../images/pgprof2.PNG)
+
+Open the C directory, and select the "laplace_data_clauses" executable.
+
+![pgprof3.PNG](../images/pgprof3.PNG)
+
+Then select OK. Your screen should look similar to this:
+
+![pgprof4.PNG](../images/pgprof4.PNG)
+
+As stated previously, if we run our program with the default 4096x4096 array, the program will take several minutes to run. I recommend that you reduce the size. Type "1024 1024" into cell labeled "Arguments", as pictured below.
+
+![pgprof5.PNG](../images/pgprof5.PNG)
+
+PGPROF will now profile your application. You will know when it is finished when you see the application output in the console window.
+
+![pgprof6.PNG](../images/pgprof6.PNG)
+
+This is the view that you should see once PGPROF is done profiling your program.
+
+![pgprof7.PNG](../images/pgprof7.PNG)
+
+We can see that our "timeline" has a lot going on. Feel free to explore the profile at this point. It will help to zoom in, so that you can better see the information.
+
+![pgprof8.PNG](../images/pgprof8.PNG)
+
+Upon zooming in, we get a much better idea of what is happening inside of our program. I have zoomed in on a single iteration of our while loop. We can see that both `calcNext` and `swap` is called. We can also see that there is a lot of space between them. It may be obvious now why our program is performing so poorly. The amount of time that our program is transferring data (as seen in the MemCpy timelines) is far greater than the time it takes running our computational functions `calcNext` and `swap`. In order to improve our performance, we need to minimize these data transfers.
+
+---
+## Managed Memory
+
+![managed_memory.png](../images/managed_memory.png)  
+
+As with many things in OpenACC, we have the option to allow the compiler to handle memory management. We will be able to achieve better performance by managing the memory ourselves, however, allowing the compiler to use managed memory is very simple, and will achieve much better performance than our naive solution from earlier. We do not need to make any changes to our code to get managed memory working. Simply run the following script. Keep in mind that unlike earlier, we are now running our code with the full sized 4096x4096 array.
+
+
+```bash
+$ pgcc -fast -ta=tesla,managed -Minfo=accel -o laplace_managed jacobi.c laplace2d.c && ./laplace_managed
+```
+
+### Optional: Compiling with the Managed Memory Flag
+
+As long as the GPU supports managed memory (see [Optional: Compiling GPU Code](#Optional:-Compiling-GPU-Code) to learn how to check if your GPU supports it), all you need to do is add the managed option to our `-ta` flag.
+
+`-ta=tesla:managed`
+
+### Profiling our Managed Memory Code
+
+Our program is doing a lot better. Let's re-profile it and see exactly why it improved. If you closed the noVNC window, you can reopen it by <a href="/vnc" target="_blank">this link.</a> To open a new profiling session, select File > New Session. Follow the steps from earlier, except select the "laplace_managed" executable. You may also emit the "Arguments". Once PGPROF is finished profiling our application, you should see the following view:  
+
+![pgprof_managed1.PNG](../images/pgprof_managed1.PNG)
+
+Feel free to explore the profile at this point. Then, when you're ready, let's zoom in.
+
+![pgprof_managed3.PNG](../images/pgprof_managed3.PNG)
+
+We can see that our compute regions (our `calcNext` and `swap` function calls) are much closer together now. There is significantly less data transfer happening between them. By using managed memory, the compiler was able to avoid the need to transfer data back and forth between the CPU and the GPU. In the next module, we will learn how to do this manually (which will boost the performance by a little bit), but for now, it is sufficient to use managed memory.
+
+---
+
+## Conclusion
+
+We have learned how to run our code on a GPU using managed memory. We also experimented a little bit with managing the data ourselves, but that didn't work out as well as we had hoped. In the next module, we will expand on these data concepts and learn the proper way to manage our data, and will no longer need to rely on the compiler.
+
+---
+
+## Bonus Task
+
+1. If you would like some additional lessons on using OpenACC to parallelize our code, there is an Introduction to OpenACC video series available from the OpenACC YouTube page. The third and fourth video in the series covers a lot of the content that was covered in this lab.  
+[Introduction to Parallel Programming with OpenACC - Part 3](https://youtu.be/Pcc3O6h-YPE)  
+[Introduction to Parallel Programming with OpenACC - Part 4](https://youtu.be/atXtVCHq8iw)
+
+## Post-Lab Summary
+
+If you would like to download this lab for later viewing, it is recommend you go to your browsers File menu (not the Jupyter notebook file menu) and save the complete web page.  This will ensure the images are copied down as well.
+
+You can also execute the following cell block to create a zip-file of the files you've been working on, and download it with the link below.
+
+
+```python
+%%bash
+rm -f openacc_files.zip
+zip -r openacc_files.zip *
+```
+
+**After** executing the above zip command, you should be able to download the zip file [here](files/openacc_files.zip)
+
+# Licensing
+This material is released by NVIDIA Corporation under the Creative Commons Attribution 4.0 International (CC BY 4.0).

--- a/labs/module4/English/Fortran/README.md
+++ b/labs/module4/English/Fortran/README.md
@@ -1,0 +1,328 @@
+# GPU Programming With OpenACC
+
+This version of the lab is intended for Fortran programmers. The C/C++ version of this lab is available [here](../C/README.md).
+
+You will receive a warning five minutes before the lab instance shuts down. Remember to save your work! If you are about to run out of time, please see the [Post-Lab](#Post-Lab-Summary) section for saving this lab to view offline later.
+
+Don't forget to check out additional [OpenACC Resources](https://www.openacc.org/resources) and join our [OpenACC Slack Channel](https://www.openacc.org/community#slack) to share your experience and get more help from the community.
+
+---
+Let's execute the cell below to display information about the GPUs running on the server. To do this, execute the cell block below by giving it focus (clicking on it with your mouse), and hitting Ctrl-Enter, or pressing the play button in the toolbar above.  If all goes well, you should see some output returned below the grey cell.
+
+
+```bash
+$ pgaccelinfo
+```
+
+## Introduction
+
+Our goal for this lab is to learn what exactly code profiling is, and how we can use it to help us write powerful parallel programs.  
+  
+  
+  
+![development_cycle.png](../images/development_cycle.png)
+
+This is the OpenACC 3-Step development cycle.
+
+**Analyze** your code, and predict where potential parallelism can be uncovered. Use profiler to help understand what is happening in the code, and where parallelism may exist.
+
+**Parallelize** your code, starting with the most time consuming parts. Focus on maintaining correct results from your program.
+
+**Optimize** your code, focusing on maximizing performance. Performance may not increase all-at-once during early parallelization.
+
+We are currently tackling the **analyze** step. We will use PGI's code profiler to get an understanding of a relatively simple sample code before moving onto the next two steps.
+
+---
+
+## Run the Code (Multicore)
+
+We have already completed a basic multicore implementation of our lab code. Run the following script IF you would prefer to use the parallel directive.
+
+
+```bash
+$ cp ./solutions/multicore/laplace2d.f90 ./laplace2d.f90
+```
+
+---
+If you would prefer to use the kernels directive, run the following script.
+
+
+```bash
+$ cp ./solutions/multicore/kernels/laplace2d.f90 ./laplace2d.f90
+```
+
+---
+Then you may run the multicore code by running the following script. An executable called **laplace_multicore** will be created.
+
+
+```bash
+$ pgfortran -fast -ta=multicore -Minfo=accel -o laplace_multicore laplace2d.f90 jacobi.f90 && ./laplace_multicore
+```
+
+### Optional: Analyze the Code
+
+If you would like a refresher on the code files that we are working on, you may view both of them using the two links below.
+
+[jacobi.f90](../../../../edit/module4/English/Fortran/jacobi.f90)  
+[laplace2d.f90](../../../../edit/module4/English/Fortran/laplace2d.f90)  
+
+### Optional: Profile the Code
+
+If you would like to profile the multicore code, you may select <a href="/vnc" target="_blank">this link.</a> When prompted for a password, type `openacc`. This will open a noVNC window, then you may use PGPROF to profile our sequential laplace code. The executable will be found in the `/home/openacc/labs/module4/English/Fortran` directory.
+
+---
+## Optional: Introduction to GPUs (Graphical Processing Units)
+
+GPUs were originally used to render computer graphics for video games. While they continue to dominate the video game hardware market, GPUs have also been adapted as a **high-throughput parallel hardware**. They excel at doing many things simultaneously.
+
+![cpu_with_gpu.png](../images/cpu_with_gpu.png)
+
+Similar to a multicore CPU, a GPU has multiple computational cores. A GPU will have many more cores, but these cores perform very badly when executing sequential serial code. Our goal when using a GPU is to only use it to offload our parallel code. All of our sequential code will continue to run on our CPU.
+
+GPUs are what is known as a SIMD architecture (SIMD stands for: single instruction, multiple data). This means that GPUs excel at taking a single computer instruction (such as a mathematical instruction, or a memory read/write) and applying that instruction to a large amount of data. Ultimately, this means that a GPU can execute thousands of operations at the same time. This function is very similar to our multicore CPU architecture, except that with a GPU, we have a many more cores at our disposal.
+
+![cpu_and_gpu_diagram.png](../images/cpu_and_gpu_diagram.png)
+
+This diagram represents a machine that contains a CPU and a GPU. We can see that the CPU and GPU are two complete seperate devices, connected via an I/O Bus. This bus is traditionally a PCI-e bus, however, NVLink is a newer, faster alternative. These two devices also have seperate memory. This means that during the execution of our program, some amount of data will be transferred between the CPU and the GPU.
+
+---
+## Data Management With OpenACC
+
+When programming for a GPU (or similar architecture), we must handle data management between the CPU and the GPU. The programmer is able to explicitly define data management by using the OpenACC **data directive and data clauses**. Otherwise, we are able to allow the copmpiler to handle all data management. Depending on the GPU (specifically older GPUs), allowing the compiler to handle data management might not be a viable option.
+
+### Using OpenACC Data Clauses
+
+Data clauses allow the programmer to specify data transfers between the host and device (or in our case, the CPU and the GPU). Let's look at an example where we do not use a data clause.
+
+```fortran
+integer, dimension(:), allocatable :: A
+allocate( A(N) )
+
+!$acc parallel loop
+do i=1,N
+   A(i) = 0
+enddo
+```
+
+We have allocated an array `A` outside of our parallel region. This means that `A` is allocated in the CPU memory. However, we access `A` inside of our loop, and that loop is contained within a `parallel` region. Within that parallel region, `A(i)` is attempting to access a memory location within the GPU memory. We didn't explicitly allocate `A` on the GPU, so one of two things will happen.
+
+1. The compiler will understand what we are trying to do, and automatically copy **A** from the CPU to the GPU.
+2. The program will check for an array **A** in GPU memory, it won't find it, and it will throw an error.
+
+Instead of hoping that we have a compiler that can figure this out, we could instead use a **data clause**.
+
+```fortran
+integer, dimension(:), allocatable :: A
+allocate( A(N) )
+
+!$acc parallel loop copy(A)
+for i=1,N
+   A(i) = 0
+enddo
+```
+
+We will learn the `copy` data clause first, because it is the easiest to use. With the inclusion of the `copy` data clause, our program will now copy the content of `A` from the CPU memory, into GPU memory. Then, during the execution of the loop, it will properly access `A` from the GPU memory. After the parallel region is finished, our program will copy `A` from the GPU memory back to the CPU memory. Let's look at one more direct example.
+
+```fortran
+integer, dimension(:), allocatable :: A
+allocate( A(N) )
+
+do i=1,N
+    A(i) = 0;
+enddo
+
+!$acc parallel loop copy(A)
+for i=1,N
+    A(i) = 1;
+enddo
+```
+
+Now we have two loops; the first loop will execute on the CPU (since it does not have an OpenACC parallel directive), and the second loop will execute on the GPU. Array `A` will be allocated on the CPU, and then the first loop will execute. This loop will set the contents of `A` to be all 0. Then the second loop is encountered; the program will copy the array `A` (which is full of 0's) into GPU memory. Then, we will execute the second loop on the GPU. This will edit the GPU's copy of `A` to be full of 1's.
+
+At this point, we have two seperate copies of `A`. The CPU copy is full of 0's, and the GPU copy is full of 1's. Now, after the parallel region finishes, the program will copy `A` back from the GPU to the CPU. After this copy, both the CPU and the GPU will contain a copy of `A` that contains all 1's. The GPU copy of `A` will then be deallocated.
+
+This image offers another step-by-step example of using the copy clause.
+
+![copy_step_by_step](../images/copy_step_by_step.png)
+
+We are also able to copy multiple arrays at once by using the following syntax.
+
+```fortran
+!$acc parallel loop copy(A, B)
+do i=1,N
+   A(i) = B(i)
+enddo
+```
+
+### Array Shaping
+
+The shape of the array specifies how much data needs to be transferred. Let's look at an example:
+
+```fortran
+!$acc parallel loop copy(A(1:N))
+do i=1,N
+   A(i) = 0
+enddo
+```
+
+Focusing specifically on the `copy(A(1:N))`, the shape of the array is defined within the brackets. The syntax for array shape is **(starting_index:ending_index)**. This means that (in the code example) we are copying data from array `A`, starting at index 1 (the start of the array), and going to the end of the array, N.
+
+We are also able to only copy a portion of the array:
+
+```fortran
+!$acc parallel copy(A(2:N-1))
+```
+
+This would copy all of the elements of `A` except for the first, and last element.
+
+Lastly, if you do not specify a starting index, 1 is assumed. This means that
+
+```fortran
+!$acc parallel loop copy(A(1:N))
+```
+
+is equivalent to
+
+```fortran
+!$acc parallel loop copy(A(:N))
+```
+
+or 
+
+```fortran
+!$acc parallel loop copy(A)
+```
+
+### Including Data Clauses in our Laplace Code
+
+Add **copy** data clause to our laplace code by selecting the following links:
+
+[jacobi.f90](../../../../edit/module4/English/Fortran/jacobi.f90)  
+[laplace2d.f90](../../../../edit/module4/English/Fortran/laplace2d.f90)  
+
+Then, when you are ready, you may run the code by running the following script. It may not be intuitively obvious yet, but we are expecting the code to perform very poorly. For this reason, we are running our GPU code on a **significantly smaller input size**. If you were to run the GPU code on the full sized input, it will take several minutes to run.
+
+
+```bash
+$ pgfortran -fast -ta=tesla:cc30 -Minfo=accel -o laplace_data_clauses laplace2d.f90 jacobi.f90  && ./laplace_data_clauses 1024 1024
+```
+
+If you are unsure about your answer, you can view the solution [here.](../../../../edit/module4/English/Fortran/solutions/basic_data/laplace2d.f90)
+
+### Optional: Compiling GPU Code
+
+Different GPUs will need to be compiled in slightly different ways. To get information about our GPU, we can use the **pgaccelinfo** command.
+
+
+```bash
+$ pgaccelinfo
+```
+
+There is a lot of information contained here, however, we are only going to focus on two points.
+
+**Managed Memory:** will tell us whether or not our GPU supports CUDA managed memory. We will cover managed memory a little bit later in the lab.
+
+**PGI Compiler Option:** tells us which target to compiler for. Ealier we were using a **-ta=multicore** flag for our multicore code. Now, to compile for our specific GPU, we will replace it with **-ta=tesla:cc30**.
+
+---
+### Profiling GPU Code
+
+In order to understand why our program is performing so poorly, we should consult our profiler.
+
+To profile our code, select <a href="/vnc" target="_blank">this link.</a> This will open a noVNC window, then you will use PGPROF to profile our edited laplace code. If prompted for a password, type `openacc`.
+
+To open a new profiling session, select File > New Session. You will be greeted with this window.
+
+![pgprof1.PNG](../images/pgprof1.PNG)
+
+Where it says "File: Enter executable file [required]", select Browse. Select File System > notebooks, then press OK.
+
+![pgprof2.PNG](../images/pgprof2.PNG)
+
+Open the C directory, and select the "laplace_data_clauses" executable.
+
+![pgprof3.PNG](../images/pgprof3.PNG)
+
+Then select OK. Your screen should look similar to this:
+
+![pgprof4.PNG](../images/pgprof4.PNG)
+
+As stated previously, if we run our program with the default 4096x4096 array, the program will take several minutes to run. I recommend that you reduce the size. Type "1024 1024" into cell labeled "Arguments", as pictured below.
+
+![pgprof5.PNG](../images/pgprof5.PNG)
+
+PGPROF will now profile your application. You will know when it is finished when you see the application output in the console window.
+
+![pgprof6.PNG](../images/pgprof6.PNG)
+
+This is the view that you should see once PGPROF is done profiling your program.
+
+![pgprof7.PNG](../images/pgprof7.PNG)
+
+We can see that our "timeline" has a lot going on. Feel free to explore the profile at this point. It will help to zoom in, so that you can better see the information.
+
+![pgprof8.PNG](../images/pgprof8.PNG)
+
+Upon zooming in, we get a much better idea of what is happening inside of our program. I have zoomed in on a single iteration of our while loop. We can see that both **calcNext** and **swap** is called. We can also see that there is a lot of space between them. It may be obvious now why our program is performing so poorly. The amount of time that our program is transferring data (as seen in the MemCpy timelines) is far greater than the time it takes running our computational functions **calcNext** and **swap**. In order to improve our performance, we need to minimize these data transfers.
+
+---
+## Managed Memory
+
+![managed_memory.png](../images/managed_memory.png)  
+
+As with many things in OpenACC, we have the option to allow the compiler to handle memory management. We will be able to achieve better performance by managing the memory ourselves, however, allowing the compiler to use managed memory is very simple, and will achieve much better performance than our naive solution from earlier. We do not need to make any changes to our code to get managed memory working. Simply run the following script. Keep in mind that unlike earlier, we are now running our code with the full sized 4096x4096 array.
+
+
+```bash
+$ pgfortran -fast -ta=tesla:managed -Minfo=accel -o laplace_managed laplace2d.f90 jacobi.f90  && ./laplace_managed
+```
+
+### Optional: Compiling with the Managed Memory Flag
+
+As long as the GPU supports managed memory (see [Optional: Compiling GPU Code](#Optional:-Compiling-GPU-Code) to learn how to check if your GPU supports it), all you need to do is add the managed option to our `-ta` flag.
+
+`-ta=tesla:cc30,managed`
+
+### Profiling our Managed Memory Code
+
+Our program is doing a lot better. Let's re-profile it and see exactly why it improved. If you closed the noVNC window, you can reopen it by <a href="/vnc" target="_blank">this link.</a> To open a new profiling session, select File > New Session. Follow the steps from earlier, except select the "laplace_managed" executable. You may also emit the "Arguments". Once PGPROF is finished profiling our application, you should see the following view:  
+
+![pgprof_managed1.PNG](../images/pgprof_managed1.PNG)
+
+Feel free to explore the profile at this point. Then, when you're ready, let's zoom in.
+
+![pgprof_managed3.PNG](../images/pgprof_managed3.PNG)
+
+We can see that our compute regions (our `calcNext` and `swap` function calls) are much closer together now. There is significantly less data transfer happening between them. By using managed memory, the compiler was able to avoid the need to transfer data back and forth between the CPU and the GPU. In the next module, we will learn how to do this manually (which will boost the performance by a little bit), but for now, it is sufficient to use managed memory.
+
+---
+
+## Conclusion
+
+We have learned how to run our code on a GPU using managed memory. We also experimented a little bit with managing the data ourselves, but that didn't work out as well as we had hoped. In the next module, we will expand on these data concepts and learn the proper way to manage our data, and will no longer need to rely on the compiler.
+
+---
+
+## Bonus Task
+
+1. If you would like some additional lessons on using OpenACC to parallelize our code, there is an Introduction to OpenACC video series available from the OpenACC YouTube page. The third and fourth video in the series covers a lot of the content that was covered in this lab.  
+[Introduction to Parallel Programming with OpenACC - Part 3](https://youtu.be/Pcc3O6h-YPE)  
+[Introduction to Parallel Programming with OpenACC - Part 4](https://youtu.be/atXtVCHq8iw)
+
+## Post-Lab Summary
+
+If you would like to download this lab for later viewing, it is recommend you go to your browsers File menu (not the Jupyter notebook file menu) and save the complete web page.  This will ensure the images are copied down as well.
+
+You can also execute the following cell block to create a zip-file of the files you've been working on, and download it with the link below.
+
+
+```python
+%%bash
+rm -f openacc_files.zip
+zip -r openacc_files.zip *
+```
+
+**After** executing the above zip command, you should be able to download the zip file [here](files/openacc_files.zip)
+
+# Licensing
+This material is released by NVIDIA Corporation under the Creative Commons Attribution 4.0 International (CC BY 4.0).

--- a/labs/module4/README.md
+++ b/labs/module4/README.md
@@ -1,0 +1,12 @@
+GPU Programming with OpenACC
+============================
+
+This lab is meant to accompany Module 4 of the OpenACC.org teaching materials.
+The purpose of this lab is to introduce GPU programming with OpenACC. Lab
+instructions and source code is available for C/C++ and Fortran.
+
+Please see the following files to begin the lab:
+
+* [C/C++](English/C/README.md)
+* [Fortran](English/Fortran/README.md)
+

--- a/labs/module5/English/C/README.md
+++ b/labs/module5/English/C/README.md
@@ -1,0 +1,444 @@
+# Data Management with OpenACC
+
+This version of the lab is intended for C/C++ programmers. The Fortran version of this lab is available [here](../Fortran/README.md).
+
+You will receive a warning five minutes before the lab instance shuts down. Remember to save your work! If you are about to run out of time, please see the [Post-Lab](#Post-Lab-Summary) section for saving this lab to view offline later.
+
+Don't forget to check out additional [OpenACC Resources](https://www.openacc.org/resources) and join our [OpenACC Slack Channel](https://www.openacc.org/community#slack) to share your experience and get more help from the community.
+
+---
+Let's execute the cell below to display information about the GPUs running on the server. To do this, execute the cell block below by giving it focus (clicking on it with your mouse), and hitting Ctrl-Enter, or pressing the play button in the toolbar above.  If all goes well, you should see some output returned below the grey cell.
+
+
+```bash
+$ pgaccelinfo
+```
+
+---
+
+## Introduction
+
+Our goal for this lab is to use the OpenACC Data Directives to properly manage our data.
+  
+  
+  
+![development_cycle.png](../images/development_cycle.png)
+
+This is the OpenACC 3-Step development cycle.
+
+**Analyze** your code, and predict where potential parallelism can be uncovered. Use profiler to help understand what is happening in the code, and where parallelism may exist.
+
+**Parallelize** your code, starting with the most time consuming parts. Focus on maintaining correct results from your program.
+
+**Optimize** your code, focusing on maximizing performance. Performance may not increase all-at-once during early parallelization.
+
+We are currently tackling the **parallelize** step. We will include the OpenACC data directive to properly manage data within our parallelized code.
+
+---
+
+## Run the Code (With Managed Memory)
+
+In the previous lab, we ran our code with CUDA Managed Memory, and achieved a considerable performance boost. However, managed memory is not compatible with all GPUs, and it performs worse than programmer defined, proper memory management. Run the following script, and note the time the program takes to run. We are expecting that our own implementation will run a little bit better.
+
+
+```bash
+$ pgcc -fast -ta=tesla:managed -Minfo=accel -o laplace_managed jacobi.c laplace2d.c && ./laplace_managed
+```
+
+### Optional: Analyze the Code
+
+If you would like a refresher on the code files that we are working on, you may view both of them using the two links below.
+
+[jacobi.c](../../../../edit/module5/English/C/jacobi.c)  
+[laplace2d.c](../../../../edit/module5/English/C/laplace2d.c)  
+
+### Optional: Profile the Code
+
+If you would like to profile the code, you may select <a href="/vnc" target="_blank">this link.</a> When prompted for a password, type `openacc`. This will open a noVNC window, then you may use PGPROF to profile our sequential laplace code. The executable will be found in the `/home/openacc/labs/module5/English/C` directory.
+
+---
+
+## OpenACC Structured Data Directive
+
+The OpenACC data directives allow the programmer to explicitly manage the data on the device (in our case, the GPU). Specifically, the structured data directive will mark a static region of our code as a **data region**.
+
+```cpp
+< Initialize data on host (CPU) >
+
+#pragma acc data < data clauses >
+{
+
+    < Code >
+
+}
+```
+
+Device memory allocation happens at the beginning of the region, and device memory deallocation happens at the end of the region. Additionally, any data movement from the host to the device (CPU to GPU) happens at the beginning of the region, and any data movement from the device to the host (GPU to CPU) happens at the end of the region. Memory allocation/deallocation and data movement is defined by which clauses the programmer includes. This is a list of the most important data clauses that we can use:
+
+**copy** : `copy( A[0:N] )` : Allocates memory on device and copies data from host to device when entering region and copies data back to the host when exiting region  
+**copyin** : `copyin( A[0:N] )` : Allocates memory on device and copies data from host to device when entering region  
+**copyout** : `copyout( A[0:N] )` : Allocates memory on device and copies data to the host when exiting region  
+**create** : `create( A[0:N] )` : Allocates memory on device but does not copy  
+**present** : `present( A )` : Data is already present on device from another containing data region  
+
+All of these data clauses (except for present) will allocate device memory at the beginning of the data region, and deallocate device memory at the end of the data region. And with the exception of create, they will also transfer some amount of data between the host and device.
+
+You may also use them to operate on multiple arrays at once, by including those arrays as a comma separated list.
+
+```cpp
+#pragma acc data copy( A[0:N], B[0:M], C[0:Q] )
+```
+
+You may also use more than one data clause at a time.
+
+```cpp
+#pragma acc data create( A[0:N] ) copyin( B[0:M] ) copyout( C[0:Q] )
+```
+
+These clauses can also be used directly with a parallel or kernels directive, because every parallel and kernels directive is surrounded by an **implied data region**.
+
+```cpp
+#pragma acc kernels create(A[0:N]) copyin(B[0:M]) present(C[0:Q])
+{
+    < Code that uses A, B, and C >
+}
+```
+
+### Encompassing Multiple Compute Regions
+
+A single data region can contain any number of parallel/kernels regions. Take the following example:
+
+```cpp
+#pragma acc data copyin(A[0:N], B[0:N]) create(C[0:N])
+{
+
+    #pragma acc parallel loop
+    for( int i = 0; i < N; i++ )
+    {
+        C[i] = A[i] + B[i];
+    }
+    
+    #pragma acc parallel loop
+    for( int i = 0; i < N; i++ )
+    {
+        A[i] = C[i] + B[i];
+    }
+
+}
+```
+
+You may also encompass function calls within the data region:
+
+```cpp
+void copy(int *A, int *B, int N)
+{
+    #pragma acc parallel loop copyout(A[0:N]) copyin(B[0:N])
+    for( int i = 0; i < N; i++ )
+    {
+        A[i] = B[i];
+    }
+}
+
+...
+
+#pragma acc data copyout(A[0:N],B[0:N]) copyin(C[0:N])
+{
+    copy(A, C, N);
+    
+    copy(A, B, N);
+}
+```
+
+But wouldn't this code now result in my arrays being copied twice, once by the data region and then again by the parallel loop inside the function calls? In fact, the OpenACC runtime is smart enough to handle exactly this case. Data will be copied in only the first time its encountered in a data clause and out only the last time its encountered in a data clause. This allows you to create fully-working directives within your functions and then later *"hoist"* the data movement to a higher level without changing your code at all. This is part of incrementally accelerating your code to avoid incorrect results.
+
+### Array Shaping
+
+The *array shape* defines a portion of an array. Take the following example:
+
+```cpp
+int *A = (int*) malloc(N * sizeof(int));
+
+#pragma acc data create( A[0:N] )
+```
+
+The array shape is defined as [0:N], this means that the GPU copy will start at index 0, and be of size N. Array shape is of the format **Array[starting_index:size]**. Let's look at an example where we only want a portion of the array.
+
+```cpp
+int *A = (int*) malloc(N * sizeof(int));
+
+#pragma acc data create( A[0:N/2] )
+```
+
+In this example, the GPU copy will start at index 0, but will only be half the size of the CPU copy.
+
+The shape of multi-dimensional arrays can be defined as follows:
+
+```cpp
+#pragma acc data create( A[0:N][0:M] )
+```
+
+If you do not include a starting index, then 0 is assumed. For example:
+
+```cpp
+#pragma acc data create( A[0:N] )
+```
+
+is equivalent to
+
+```cpp
+#pragma acc data create( A[:N] )
+```
+
+### Host or Device Memory?
+
+Here are two loops:
+
+```cpp
+int *A = (int*) malloc(N * sizeof(int));
+
+for (int i = 0; i < N; i++ )
+{
+    A[i] = 0;
+}
+
+#pragma acc parallel loop
+for( int i = 0; i < N; i++ )
+{
+    A[i] = 1;
+}
+```
+
+The first loop is not contained within an OpenACC compute region (a compute region is marked by either the parallel or kernels directive). Thus, `A[i]` will access host (CPU) memory.
+
+The second loop is preceeded by the parallel directive, meaning that it is contained within an OpenACC compute region. `A[i]` in the second loop will access device (GPU) memory.
+
+### Adding the Structured Data Directive to our Code
+
+Use the following links to edit our laplace code. Add a structured data directive to properly handle the arrays `A` and `Anew`. 
+
+[jacobi.c](../../../../edit/module5/English/C/jacobi.c)   
+[laplace2d.c](../../../../edit/module5/English/C/laplace2d.c)  
+
+Then, run the following script to check you solution. You code should run just as good as (or slightly better) than our managed memory code.
+
+
+```bash
+$ pgcc -fast -ta=tesla -Minfo=accel -o laplace_structured jacobi.c laplace2d.c && ./laplace_structured
+```
+
+If you are feeling stuck, or would like to check your answer, you can view the correct answer with the following link.
+
+[jacobi.c](../../../../edit/module5/English/C/solutions/advanced_data/structured/jacobi.c)
+
+### Optional: Profile the Code
+
+If you would like to profile the code, you may select <a href="/vnc" target="_blank">this link.</a> This will open a noVNC window. If prompted for a password, type `openacc`. To create a new session, select File > New Session. In the "File" section, select "Browse". Locate our **laplace_structured** executable in the `/home/openacc/labs/module5/English/C` directory. The select OK > Next > Finished. The code will take a few seconds to finish profiling.
+
+Take a moment to explore the profiler, and when you're ready, let's zoom in on the very beginning of our profile.
+
+![structured_pgprof1.PNG](../images/structured_pgprof1.PNG)
+
+We can see that we have uninterupted computation, and all of our data movement happens at the beginning of the program. This is ideal, because we are avoiding data transers in the middle of our computation.
+
+---
+
+## OpenACC Unstructured Data Directives
+
+There are two unstructured data directives:
+
+**enter data**: Handles device memory allocation, and copies from the Host to the Device. The two clauses that you may use with `enter data` are `create` for device memory allocation, and `copyin` for allocation, and memory copy.
+
+**exit data**: Handles device memory deallocation, and copies from the Device to the Host. The two clauses that you may use with `exit data` are `delete` for device memory deallocation, and `copyout` for deallocation, and memory copy.
+
+The unstructured data directives do not mark a "data region", because you are able to have multiple `enter data` and `exit data` directives in your code. It is better to think of them purely as memory allocation and deallocation.
+
+The largest advantage of using unstructured data directives is their ability to branch across multiple functions. You may allocate your data in one function, and deallocate it in another. We can look at a simple example of that:
+
+```cpp
+int* allocate(int size)
+{
+    int *ptr = (int*) malloc(size * sizeof(int));
+    #pragma acc enter data create(ptr[0:size])
+    return ptr;
+}
+
+void deallocate(int *ptr)
+{
+    #pragma acc exit data delete(ptr)
+    free(ptr);
+}
+
+int main()
+{
+    int *ptr = allocate(100);
+    
+    #pragma acc parallel loop
+    for( int i = 0; i < 100; i++ )
+    {
+        ptr[i] = 0;
+    }
+    
+    deallocate(ptr);
+}
+```
+
+Just like in the above code sample, you must first allocate the CPU copy of the array **before** you can allocate the GPU copy. Also, you must deallocate the GPU of the array **before** you deallocate the CPU copy.
+
+### Adding Unstructured Data Directives to our Code
+
+We are going to edit our code to use unstructured data directives to handle memory management. First, run the following script to reset your code to how it was before adding the structured data directive.
+
+
+```bash
+$ cp ./solutions/basic_data/jacobi.c ./jacobi.c && cp ./solutions/basic_data/laplace2d.c ./laplace2d.c && echo "Reset Finished"
+```
+
+Now edit the code to use unstructured data directives. To fully utilize the unstructured data directives, try to get the code working by only altering the **laplace2d.c** code.
+
+[jacobi.c](../../../../edit/module5/English/C/jacobi.c)   
+[laplace2d.c](../../../../edit/module5/English/C/laplace2d.c)  
+
+Run the following script to check your solution. Your code should run as fast as our structured implementation.
+
+
+```bash
+$ pgcc -fast -ta=tesla -Minfo=accel -o laplace_unstructured jacobi.c laplace2d.c && ./laplace_unstructured
+```
+
+If you are feeling stuck, or would like to check your answer, you can view the correct answer with the following link.
+
+[laplace2d.c](../../../../edit/module5/English/C/solutions/advanced_data/unstructured/laplace2d.c)
+
+### Optional: Profile the Code
+
+If you would like to profile the code, you may select <a href="/vnc" target="_blank">this link.</a> This will open a noVNC window. To create a new session, select File > New Session. In the "File" section, select "Browse". Locate our **laplace_unstructured** executable in the /notebooks/C directory. The select OK > Next > Finished. The code will take a few seconds to finish profiling.
+
+Take a moment to explore the profiler, and when you're ready, let's zoom in on the very beginning of our profile.
+
+![unstructured_pgprof1.PNG](../images/unstructured_pgprof1.PNG)
+
+We can see that we have uninterupted computation, and all of our data movement happens at the beginning of the program. This is ideal, because we are avoiding data transers in the middle of our computation. If you also profiled the structured version of the code, you will notice that the profiles are nearly identical. This isn't surprising, since the structured and unstructured approach work very similarly at the hardware level. However, structured data regions may be easier in simple codes, whereas some codes might flow better when using an unstructured approach. It is up to the programmer to decide which to use.
+
+---
+
+## OpenACC Update Directive
+
+When we use the data directives, there exist two places where the programmer can transfer data between the host and the device. For the structured data directive we have the opportunity to transfer data at the beginning and at the end of the region. For the unstructured data directives, we can transfer data when we use the enter data and exit data directives.
+
+However, there may be times in your program where you need to transfer data in the middle of a data region, or between an enter data and an exit data. In order to transfer data at those times, we can use the `update` directive. The update directive will explicitly transfer data between the host and the device. The `update` directive has two clauses:
+
+**self**: The self clause will transfer data from the device to the host (GPU to CPU)  
+**device**: The device clause will transfer data from the host to the device (CPU to GPU)
+
+The syntax would look like:
+
+`#pragma acc update self(A[0:N])`
+
+`#pragma acc update device(A[0:N])`
+
+All of the array shaping rules apply.
+
+As an example, let's create a version of our laplace code where we want to print the array **A** after every 100 iterations of our loop. The code will look like this:
+
+```cpp
+#pragma acc data copyin( A[:m*n],Anew[:m*n] )
+{
+    while ( error > tol && iter < iter_max )
+    {
+        error = calcNext(A, Anew, m, n);
+        swap(A, Anew, m, n);
+        
+        if(iter % 100 == 0)
+        {
+            printf("%5d, %0.6f\n", iter, error);
+            for( int i = 0; i < n; i++ )
+            {
+                for( int j = 0; j < m; j++ )
+                {
+                    printf("%0.2f ", A[i+j*m]);
+                }
+                printf("\n");
+            }
+        }
+        
+        iter++;
+
+    }
+}
+```
+
+Let's run this code (on a very small data set, so that we don't overload the console by printing thousands of numbers).
+
+
+```bash
+$ cd update && pgcc -fast -ta=tesla -Minfo=accel -o laplace_no_update jacobi.c laplace2d.c && ./laplace_no_update 10 10
+```
+
+We can see that the array is not changing. This is because the host copy of `A` is not being **updated** between loop iterations. Let's add the update directive, and see how the output changes.
+
+```cpp
+#pragma acc data copyin( A[:m*n],Anew[:m*n] )
+{
+    while ( error > tol && iter < iter_max )
+    {
+        error = calcNext(A, Anew, m, n);
+        swap(A, Anew, m, n);
+        
+        if(iter % 100 == 0)
+        {
+            printf("%5d, %0.6f\n", iter, error);
+            
+            #pragma acc update self(A[0:m*n])
+            
+            for( int i = 0; i < n; i++ )
+            {
+                for( int j = 0; j < m; j++ )
+                {
+                    printf("%0.2f ", A[i+j*m]);
+                }
+                printf("\n");
+            }
+        }
+        
+        iter++;
+
+    }
+}
+```
+
+
+```bash
+$ cd update/solution && pgcc -fast -ta=tesla -Minfo=accel -o laplace_update jacobi.c laplace2d.c && ./laplace_update 10 10
+```
+
+---
+
+## Conclusion
+
+Relying on managed memory to handle data management can reduce the effort the programmer needs to parallelize their code, however, not all GPUs work with managed memory, and it is also lower performance than using explicit data management. OpenACC gives the programmer two main ways to handle data management, structured and unstructured data directives. By using these, the programmer is able to minimize the number of data transfers needed in their program.
+
+---
+
+## Bonus Task
+
+If you would like some additional lessons on using OpenACC, there is an Introduction to OpenACC video series available from the OpenACC YouTube page. The fifth video in the series covers a lot of the content that was covered in this lab.  
+
+[Introduction to Parallel Programming with OpenACC - Part 5](https://youtu.be/0zTX7-CPvV8)  
+
+## Post-Lab Summary
+
+If you would like to download this lab for later viewing, it is recommend you go to your browsers File menu (not the Jupyter notebook file menu) and save the complete web page.  This will ensure the images are copied down as well.
+
+You can also execute the following cell block to create a zip-file of the files you've been working on, and download it with the link below.
+
+
+```python
+%%bash
+rm -f openacc_files.zip
+zip -r openacc_files.zip *
+```
+
+**After** executing the above zip command, you should be able to download the zip file [here](files/openacc_files.zip)
+
+# Licensing
+This material is released by NVIDIA Corporation under the Creative Commons Attribution 4.0 International (CC BY 4.0).

--- a/labs/module5/English/Fortran/README.md
+++ b/labs/module5/English/Fortran/README.md
@@ -1,0 +1,477 @@
+# Data Management with OpenACC
+
+This version of the lab is intended for Fortran programmers. The C/C++ version of this lab is available [here](../C/README.md).
+
+You will receive a warning five minutes before the lab instance shuts down. Remember to save your work! If you are about to run out of time, please see the [Post-Lab](#Post-Lab-Summary) section for saving this lab to view offline later.
+
+Don't forget to check out additional [OpenACC Resources](https://www.openacc.org/resources) and join our [OpenACC Slack Channel](https://www.openacc.org/community#slack) to share your experience and get more help from the community.
+
+---
+Let's execute the cell below to display information about the GPUs running on the server. To do this, execute the cell block below by giving it focus (clicking on it with your mouse), and hitting Ctrl-Enter, or pressing the play button in the toolbar above.  If all goes well, you should see some output returned below the grey cell.
+
+
+```bash
+$ pgaccelinfo
+```
+
+---
+
+## Introduction
+
+Our goal for this lab is to use the OpenACC Data Directives to properly manage our data.We are going to use the same development cycle that we have used to this point. That is the 3-step development cycle.
+  
+  
+  
+![development_cycle.png](../images/development_cycle.png)
+
+This is the OpenACC 3-Step development cycle.
+
+**Analyze** your code, and predict where potential parallelism can be uncovered. Use profiler to help understand what is happening in the code, and where parallelism may exist.
+
+**Parallelize** your code, starting with the most time consuming parts. Focus on maintaining correct results from your program.
+
+**Optimize** your code, focusing on maximizing performance. Performance may not increase all-at-once during early parallelization.
+
+We are currently tackling the **parallelize** step. We will include the OpenACC data directive to properly manage data within our parallelized code.
+
+---
+
+## Run the Code (With Managed Memory)
+
+In the previous lab, we ran our code with CUDA Managed Memory, and achieved a considerable performance boost. However, managed memory is not compatible with all GPUs, and it performs worse than programmer defined, proper memory management. Run the following script, and note the time the program takes to run. We are expecting that our own implementation will run a little bit better.
+
+
+```bash
+$ pgfortran -fast -ta=tesla:managed -Minfo=accel -o laplace_managed laplace2d.f90 jacobi.f90 && ./laplace_managed
+```
+
+### Optional: Analyze the Code
+
+If you would like a refresher on the code files that we are working on, you may view both of them using the two links below.
+
+[jacobi.f90](../../../../edit/module5/English/Fortran/jacobi.f90)  
+[laplace2d.f90](../../../../edit/module5/English/Fortran/laplace2d.f90)  
+
+### Optional: Profile the Code
+
+If you would like to profile the code, you may select <a href="/vnc" target="_blank">this link.</a> When prompted for a password, type `openacc`. This will open a noVNC window, then you may use PGPROF to profile our laplace code. The executable will be found in the `/home/openacc/labs/module6/English/Fortran` directory.
+
+---
+
+## OpenACC Structured Data Directive
+
+The OpenACC data directives allow the programmer to explicitly manage the data on the device (in our case, the GPU). Specifically, the structured data directive will mark a static region of our code as a **data region**.
+
+```fortran
+< Initialize data on host (CPU) >
+
+!$acc data clauses
+
+	< Sequential and/or Parallel code >
+
+!$acc end data
+```
+
+Device memory allocation happens at the beginning of the region, and device memory deallocation happens at the end of the region. Additionally, any data movement from the host to the device (CPU to GPU) happens at the beginning of the region, and any data movement from the device to the host (GPU to CPU) happens at the end of the region. Memory allocation/deallocation and data movement is defined by which clauses the programmer includes. This is a list of the most important data clauses that we can use:
+
+**copy** : `copy( A(1:N) )` : Allocates memory on device and copies data from host to device when entering region and copies data back to the host when exiting region  
+**copyin** : `copyin( A(1:N) )` : Allocates memory on device and copies data from host to device when entering region  
+**copyout** : `copyout( A(1:N) )` : Allocates memory on device and copies data to the host when exiting region  
+**create** : `create( A(1:N) )` : Allocates memory on device but does not copy  
+**present** : `present( A )` : Data is already present on device from another containing data region  
+
+All of these data clauses (except for present) will allocate device memory at the beginning of the data region, and deallocate device memory at the end of the data region. And with the exception of create, they will also transfer some amount of data between the host and device.
+
+You may also use them to operate on multiple arrays at once, by including those arrays as a comma separated list.
+
+```fortran
+!$acc data copy( A(1:N), B(1:M), C(1:Q) )
+```
+
+You may also use more than one data clause at a time.
+
+```fortran
+!$acc data create( A(1:N) ) copyin( B(1:M) ) copyout( C(1:Q) )
+```
+
+These clauses can also be used directly with a parallel or kernels directive, because every parallel and kernels directive is surrounded by an **implied data region**.
+
+```fortran
+!$acc kernels create(A(1:N)) copyin(B(1:M)) present(C(1:Q))
+
+    < Code that uses A, B, and C >
+
+```
+
+### Encompassing Multiple Compute Regions
+
+A single data region can contain any number of parallel/kernels regions. Take the following example:
+
+```fortran
+!$acc data copyin(A, B) create(C)
+
+    !acc parallel loop
+    for i=1,N
+        C(i) = A(i) + B(i)
+    enddo
+    
+    !acc parallel loop
+    do i=1,N
+        A(i) = C(i) + B(i)
+    enddo
+
+```
+
+You may also encompass function calls within the data region:
+
+```fortran
+subroutine copy(A, B, N)
+integer :: A(:), B(:), N
+
+!$acc parallel loop copyout(A) copyin(B)
+do i=1,N
+   A(i) = B(i)
+enddo
+
+end subroutine copy
+
+
+...
+
+!$acc data copyout(A,B) copyin(C)
+call copy(A, C, N);
+    
+call copy(A, B, N);
+!$acc end data
+```
+
+
+But wouldn't this code now result in my arrays being copied twice, once by the data region and then again by the parallel loop inside the function calls? In fact, the OpenACC runtime is smart enough to handle exactly this case. Data will be copied in only the first time its encountered in a data clause and out only the last time its encountered in a data clause. This allows you to create fully-working directives within your functions and then later *"hoist"* the data movement to a higher level without changing your code at all. This is part of incrementally accelerating your code to avoid incorrect results.
+
+### Array Shaping
+
+The "array shape" defines a portion of an array. Take the following example:
+
+```fortran
+integer, dimension(:), allocatable :: A
+allocate( A(N) )
+
+!$acc data create( A )
+```
+
+The array shape is not defined, this means that the GPU copy will start at index 1, and be of size N (i.e. the entire array). However, you can specify a subset of the array using as A(2:N-1). Array shape is of the format **Array(starting_index:ending_index)**. Let's look at an example where we only want a portion of the array.
+
+```fortran
+integer, dimension(:), allocatable :: A
+allocate( A(N) )
+
+!$acc data create( A(1:N/2) )
+```
+
+In this example, the GPU copy will start at index 1, but will only be half the size of the CPU copy.
+
+The shape of multi-dimensional arrays can be defined as follows:
+
+```fortran
+!$acc data create( A(1:N,1:M) )
+```
+
+If you do not include a starting index, then 1 is assumed. For example:
+
+```fortran
+!$acc data create( A(1:N) )
+```
+
+is equivalent to
+
+```fortran
+!$acc data create( A(:N) )
+```
+
+In Fortran, if you don't specify any of the indices, **starting_index** or **ending_index** then the compiler will assume you mean the entire array using the starting and ending indexes of the array on the CPU. An example is,
+
+```fortran
+!$acc data create( A )
+```
+
+### Host or Device Memory?
+
+Here are two loops:
+
+```fortran
+integer, dimension(:), allocatable :: A
+allocate( A(N) )
+
+do i=1,N
+    A(i) = 0
+enddo
+
+!$acc parallel loop
+do i=1,N
+    A(i) = 1
+enddo
+```
+
+The first loop is not contained within an OpenACC compute region (a compute region is marked by either the parallel or kernels directive). Thus, `A(i)` will access host (CPU) memory.
+
+The second loop is preceeded by the parallel directive, meaning that it is contained within an OpenACC compute region. `A(i)` in the second loop will access device (GPU) memory.
+
+### Adding the Structured Data Directive to our Code
+
+Use the following links to edit our laplace code. Add a structured data directive to properly handle the arrays **A** and **Anew**. 
+
+[jacobi.f90](../../../../edit/module5/English/Fortran/jacobi.f90)   
+[laplace2d.f90](../../../../edit/module5/English/Fortran/laplace2d.f90)  
+
+Then, run the following script to check you solution. You code should run just as good as (or slightly better) than our managed memory code.
+
+
+```bash
+$ pgfortran -fast -ta=tesla -Minfo=accel -o laplace_structured laplace2d.f90 jacobi.f90 && ./laplace_structured
+```
+
+If you are feeling stuck, or would like to check your answer, you can view the correct answer with the following link.
+
+[jacobi.f90](../../../../edit/module5/English/Fortran/solutions/advanced_data/structured/jacobi.f90)
+
+### Optional: Profile the Code
+
+If you would like to profile the code, you may select <a href="/vnc" target="_blank">this link.</a> This will open a noVNC window. If prompted for a password, type `openacc`. To create a new session, select File > New Session. In the "File" section, select "Browse". Locate our **laplace_structured** executable in the `/home/openacc/labs/module5/English/Fortran` directory. The select OK > Next > Finished. The code will take a few seconds to finish profiling.
+
+Take a moment to explore the profiler, and when you're ready, let's zoom in on the very beginning of our profile.
+
+![structured_pgprof1.PNG](../images/structured_pgprof1.PNG)
+
+We can see that we have uninterupted computation, and all of our data movement happens at the beginning of the program. This is ideal, because we are avoiding data transers in the middle of our computation.
+
+---
+
+## OpenACC Unstructured Data Directives
+
+There are two unstructured data directives:
+
+**enter data**: Handles device memory allocation, and copies from the Host to the Device. The two clauses that you may use with `enter data` are `create` for device memory allocation, and `copyin` for allocation, and memory copy.
+
+**exit data**: Handles device memory deallocation, and copies from the Device to the Host. The two clauses that you may use with `exit data` are `delete` for device memory deallocation, and `copyout` for deallocation, and memory copy.
+
+The unstructured data directives do not mark a "data region", because you are able to have multiple `enter data` and `exit data` directives in your code. It is better to think of them purely as memory allocation and deallocation.
+
+The largest advantage of using unstructured data directives is their ability to branch across multiple functions. You may allocate your data in one function, and deallocate it in another. We can look at a simple example of that:
+
+```fortran
+subroutine intallocate(A,N)
+    integer :: N
+    integer, allocatable, dimension(:) :: A
+
+    allocate( A(1:N) )
+    !acc enter data create (A(1:N))
+end subroutine intallocate
+
+subroutine intdeallocate(A,N)
+    integer :: N
+    integer, allocatable, dimension(:) :: A
+
+    !acc exit data delete(A(1:N))
+    if (allocated(A)) deallocate(A)
+end subroutine intdeallocate
+
+
+program main
+    integer, allocatable, dimension(:) :: A
+
+    call intallocate(A,100)
+    
+    !acc parallel loop
+    do i=1,100
+        A(i) = 0
+    enddo
+    
+    call intdeallocate(A,100)
+end program main
+```
+
+Just like in the above code sample, you must first allocate the CPU copy of the array **before** you can allocate the GPU copy. Also, you must deallocate the GPU of the array **before** you deallocate the CPU copy.
+
+### Adding Unstructured Data Directives to our Code
+
+We are going to edit our code to use unstructured data directives to handle memory management. First, run the following script to reset your code to how it was before adding the structured data directive.
+
+
+```bash
+$ cp ./solutions/basic_data/jacobi.f90 ./jacobi.f90 && cp ./solutions/basic_data/laplace2d.f90 ./laplace2d.f90 && echo "Reset Finished"
+```
+
+Now edit the code to use unstructured data directives. To fully utilize the unstructured data directives, try to get the code working by only altering the **laplace2d.f90** code.
+
+[jacobi.f90](../../../../edit/module5/English/Fortran/jacobi.f90)   
+[laplace2d.f90](../../../../edit/module5/English/Fortran/laplace2d.f90)  
+
+Run the following script to check your solution. Your code should run as fast as our structured implementation.
+
+
+```bash
+$ pgfortran -fast -ta=tesla -Minfo=accel -o laplace_unstructured laplace2d.f90 jacobi.f90 && ./laplace_unstructured
+```
+
+If you are feeling stuck, or would like to check your answer, you can view the correct answer with the following link.
+
+[laplace2d.f90](../../../../edit/module5/English/Fortran/solutions/advanced_data/unstructured/laplace2d.f90)
+
+### Optional: Profile the Code
+
+If you would like to profile the code, you may select <a href="/vnc" target="_blank">this link.</a> This will open a noVNC window. To create a new session, select File > New Session. In the "File" section, select "Browse". Locate our **laplace_unstructured** executable in the /notebooks/Fortran directory. The select OK > Next > Finished. The code will take a few seconds to finish profiling.
+
+Take a moment to explore the profiler, and when you're ready, let's zoom in on the very beginning of our profile.
+
+![unstructured_pgprof1.PNG](../images/unstructured_pgprof1.PNG)
+
+We can see that we have uninterupted computation, and all of our data movement happens at the beginning of the program. This is ideal, because we are avoiding data transers in the middle of our computation. If you also profiled the structured version of the code, you will notice that the profiles are nearly identical. This isn't surprising, since the structured and unstructured approach work very similarly at the hardware level. However, structured data regions may be easier in simple codes, whereas some codes might flow better when using an unstructured approach. It is up to the programmer to decide which to use.
+
+---
+
+## OpenACC Update Directive
+
+When we use the data directives, there exist two places where the programmer can transfer data between the host and the device. For the structured data directive we have the opportunity to transfer data at the beginning and at the end of the region. For the unstructured data directives, we can transfer data when we use the enter data and exit data directives.
+
+However, there may be times in your program where you need to transfer data in the middle of a data region, or between an enter data and an exit data. In order to transfer data at those times, we can use the `update` directive. The update directive will explicitly transfer data between the host and the device. The `update` directive has two clauses:
+
+**self**: The self clause will transfer data from the device to the host (GPU to CPU)  
+**device**: The device clause will transfer data from the host to the device (CPU to GPU)
+
+The syntax would look like:
+
+`!$acc update self(A)`
+
+`!$acc update device(A)`
+
+All of the array shaping rules apply.
+
+As an example, let's create a version of our laplace code where we want to print the array **A** after every 100 iterations of our loop. The code will look like this:
+
+```fortran
+!$acc data copyin(A(n,m), Anew(n,m))
+do while (error > tol && iter < iter_max)
+    error = calcNext(A, Anew, m, n)
+    swap(A, Anew, m, n)
+    
+    if (mod(iter,100) == 0) then
+        write(*,'(i5,f10.6)'), iter, error
+        do i=1,n
+            do j=1,m
+                write(*,'(f10.2)', advance="no"), A(i,j)
+            enddo
+            write(*,*) ' '
+        enddo
+    endif
+
+    iter = iter + 1
+enddo
+```
+
+Let's run this code (on a very small data set, so that we don't overload the console by printing thousands of numbers).
+
+Note: You will have to edit jacobi.f90 and change the dimensions of the problem from 4096 to 10. Otherwise the code will take a long time to run and it will produce a great deal of output to the screen.
+
+**Once again**, please change the dimenions of the problem, `n` and `m` to 10. Originally the line in jacobi.f90 will be the following.
+
+```fortran
+integer, parameter :: n=4096, m=4096, iter_max=1000
+```
+
+That line in the jacobi.f90 now needs to look like the following
+
+```fortran
+integer, parameter :: n=10, m=10, iter_max=1000
+```
+
+The simple reason is that the Fortran code does not have command line argument capability while the C version does. Clicking on the links below will allow you to edit the code.
+
+[jacobi.f90](../../../../edit/module5/English/Fortran/update/jacobi.f90)  
+[laplace2d.f90](../../../../edit/module5/English/Fortran/update/laplace2d.f90)   
+
+
+
+```bash
+$ cd update && pgfortran -fast -ta=tesla -Minfo=accel -o laplace_no_update laplace2d.f90 jacobi.f90 && ./laplace_no_update
+```
+
+We can see that the array is not changing. This is because the host copy of `A` is not being **updated** between loop iterations. Let's add the update directive, and see how the output changes.
+
+```fortran
+!$acc data copyin( A(n,m), Anew(n,m))
+
+do while (error > tol && iter < iter_max)
+    error = calcNext(A, Anew, m, n)
+    swap(A, Anew, m, n)
+    
+    if (mod(iter,100) == 0)
+        write(*,'(i5,f10.6)'), iter, error
+        
+        !acc update self(A(n,m))
+        do i=1,n
+            do j=1,m
+                write(*,'(f10.2)', advance="no"), A(i,j)
+            enddo
+        enddo
+    endif
+    iter = iter+1
+    
+end do
+```
+
+Note: You will have to edit jacobi.f90 and change the dimensions of the problem from 4096 to 10. Otherwise the code will take a long time to run and it will produce a great deal of output to the screen.
+
+**Once again**, please change the dimenions of the problem, `n` and `m` to 10. Originally the line in jacobi.f90 will be the following.
+
+```fortran
+integer, parameter :: n=4096, m=4096, iter_max=1000
+```
+
+That line in the jacobi.f90 now needs to look like the following
+
+```fortran
+integer, parameter :: n=10, m=10, iter_max=1000
+```
+
+The simple reason is that the Fortran code does not have command line argument capability while the C version does. Clicking on the links below will allow you to edit the code.
+
+[jacobi.f90](../../../../edit/module5/English/Fortran/update/solution/jacobi.f90)  
+[laplace2d.f90](../../../../edit/module5/English/Fortran/update/solution/laplace2d.f90)   
+
+
+
+```bash
+$ cd update/solution && pgfortran -fast -ta=tesla -Minfo=accel -o laplace_update laplace2d.f90 jacobi.f90 && ./laplace_update
+```
+
+---
+
+## Conclusion
+
+Relying on managed memory to handle data management can reduce the effort the programmer needs to parallelize their code, however, not all GPUs work with managed memory, and it is also lower performance than using explicit data management. OpenACC gives the programmer two main ways to handle data management, structured and unstructured data directives. By using these, the programmer is able to minimize the number of data transfers needed in their program.
+
+---
+
+## Bonus Task
+
+If you would like some additional lessons on using OpenACC, there is an Introduction to OpenACC video series available from the OpenACC YouTube page. The fifth video in the series covers a lot of the content that was covered in this lab.  
+
+[Introduction to Parallel Programming with OpenACC - Part 5](https://youtu.be/0zTX7-CPvV8)  
+
+## Post-Lab Summary
+
+If you would like to download this lab for later viewing, it is recommend you go to your browsers File menu (not the Jupyter notebook file menu) and save the complete web page.  This will ensure the images are copied down as well.
+
+You can also execute the following cell block to create a zip-file of the files you've been working on, and download it with the link below.
+
+
+```python
+%%bash
+rm -f openacc_files.zip
+zip -r openacc_files.zip *
+```
+
+**After** executing the above zip command, you should be able to download the zip file [here](files/openacc_files.zip)
+
+# Licensing
+This material is released by NVIDIA Corporation under the Creative Commons Attribution 4.0 International (CC BY 4.0).

--- a/labs/module5/README.md
+++ b/labs/module5/README.md
@@ -1,0 +1,12 @@
+Data Management with OpenACC
+============================
+
+This lab is meant to accompany Module 5 of the OpenACC.org teaching materials.
+The purpose of this lab is to introduce OpenACC data management directives. Lab
+instructions and source code is available for C/C++ and Fortran.
+
+Please see the following files to begin the lab:
+
+* [C/C++](English/C/README.md)
+* [Fortran](English/Fortran/README.md)
+

--- a/labs/module6/English/C/README.md
+++ b/labs/module6/English/C/README.md
@@ -1,0 +1,640 @@
+# OpenACC Loop Optimizations
+
+This version of the lab is intended for C/C++ programmers. The Fortran version of this lab is available [here](../Fortran/README.md).
+
+You will receive a warning five minutes before the lab instance shuts down. Remember to save your work! If you are about to run out of time, please see the [Post-Lab](#Post-Lab-Summary) section for saving this lab to view offline later.
+
+Don't forget to check out additional [OpenACC Resources](https://www.openacc.org/resources) and join our [OpenACC Slack Channel](https://www.openacc.org/community#slack) to share your experience and get more help from the community.
+
+---
+Let's execute the cell below to display information about the GPUs running on the server. To do this, execute the cell block below by giving it focus (clicking on it with your mouse), and hitting Ctrl-Enter, or pressing the play button in the toolbar above.  If all goes well, you should see some output returned below the grey cell.
+
+
+```bash
+$ pgaccelinfo
+```
+
+---
+
+## Introduction
+
+Our goal for this lab is to use the OpenACC Loop clauses to opimize our Parallel Loops.
+  
+  
+  
+![development_cycle.png](../images/development_cycle.png)
+
+This is the OpenACC 3-Step development cycle.
+
+**Analyze** your code, and predict where potential parallelism can be uncovered. Use profiler to help understand what is happening in the code, and where parallelism may exist.
+
+**Parallelize** your code, starting with the most time consuming parts. Focus on maintaining correct results from your program.
+
+**Optimize** your code, focusing on maximizing performance. Performance may not increase all-at-once during early parallelization.
+
+We are currently tackling the **optimize** step. We will include the OpenACC loop clauses to optimize the execution of our parallel loop nests.
+
+---
+
+## Run the Code
+
+In the previous labs, we have built up a working parallel code that can run on both a multicore CPU and a GPU. Let's run the code and note the performance, so that we can compare the runtime to any future optimizations we make.
+
+
+```bash
+$ pgcc -fast -ta=tesla -Minfo=accel -o laplace_baseline jacobi.c laplace2d.c && ./laplace_baseline
+```
+
+### Optional: Analyze the Code
+
+If you would like a refresher on the code files that we are working on, you may view both of them using the two links below.
+
+[jacobi.c](../../../../edit/module6/English/C/jacobi.c)  
+[laplace2d.c](../../../../edit/module6/English/C/laplace2d.c)  
+
+### Optional: Profile the Code
+
+If you would like to profile the code, you may select <a href="/vnc" target="_blank">this link.</a> When prompted for a password, type `openacc`. This will open a noVNC window, then you may use PGPROF to profile our laplace code. The executable will be found in the `/home/openacc/labs/module6/English/C` directory.
+
+---
+
+## OpenACC Loop Directive
+
+The loop directive allows us to mark specific loops for parallelization. The loop directive also allows us to map specific optimizations/alterations to our loops using **loop clauses**. Not all loop clauses are used to optimize our code; some are also used to verify code correctness. A few examples of the loop directive are as follows:
+
+```cpp
+#pragma acc parallel loop < loop clauses >
+for(int i = 0; i < N; i++)
+{
+    < loop code >
+}
+```
+
+```cpp
+#pragma acc kernels loop < loop clauses >
+for(int i = 0; i < N; i++)
+{
+    < loop code >
+}
+```
+
+```cpp
+#pragma acc parallel loop < loop clauses >
+for(int i = 0; i < N; i++)
+{
+    #pragma acc loop < loop clauses >
+    for(int j = 0; j < M; j++)
+    {
+        < loop code >
+    }
+}
+```
+
+Also, including loop optimizations does not always optimize the code. It is up to the programmer to decide which loop optimizations will work best for their loops.
+
+### Independent Clause
+
+When using the `kernels` directive, the compiler will decide which loops are, and are not, parallelizable. However, the programmer can override this compiler decision by using the `independent` clause. The `independent` clause is a way for the programmer to guarantee to the compiler that a loop is **parallelizable**.
+
+```cpp
+#pragma acc kernels loop independent
+for(int i = 0; i < N; i++)
+{
+    < Parallel Loop Code >
+}
+
+#pragma acc kernels
+{
+    for(int i = 0; i < N; i++)
+    {
+        < Parallel Loop Code >
+    }
+    
+    #pragma acc loop independent
+    for(int i = 0; i < N; i++)
+    {
+        < Parallel Loop Code >
+    }
+}
+```
+
+In the second example, we have two loops. The compiler will make a decision whether or not the first loop is parallelizable. In the second loop however, we have included the independent clause. This means that the compiler will trust the programmer, and assume that the second loop is parallelizable.
+
+When using the `parallel` directive, the `independent` clause is automatically implied on all `loop` directives contained within. This means that you do not need to use the `independent` clause when you are using the `parallel` directive.
+
+### Auto Clause
+
+The `auto` clause is more-or-less the complete opposite of the `independent` clause. When you are using the `parallel` directive, the compiler will trust anything that the programmer decides. This means that if the programmer believes that a loop is parallelizable, the compiler will trust the programmer. However, if you include the auto clause with your loops, the compiler will double check the loops, and decide whether or not to parallelize them.
+
+```cpp
+#pragma acc parallel loop auto
+for(int i = 0; i < N; i++)
+{
+    < Parallel Loop Code >
+}
+```
+
+The `independent` clause is a way for the programmer to assert to the compiler that a loop is parallelizable. The `auto` clause is a way for the programmer to tell the compiler to analyze the loop, and to determine whether or not it is parallelizable.
+
+### Seq Clause
+
+The `seq` clause (short for *"sequential"*) is used to define a loop that should run sequentially on the parallel hardware. This loop clause is usually automatically applied to large, multidimensional loop nests, since the compiler may only be able to describe parallelism for the outer-most loops. For example:
+
+```cpp
+for(int i = 0; i < N; i++)
+{
+    for(int j = 0; j < M; j++)
+    {
+        for(int k = 0; k < Q; k++)
+        {
+            < Loop Code >
+        }
+    }
+}
+```
+
+The compiler may only be able to parallelize the `i` and `j` loops, and will choose to run the `k` loop **sequentially**. The `seq` clause is also useful for running very small, nested loops sequentially. For example:
+
+```cpp
+for(int i = 0; i < 1000000; i++)
+{
+    for(int j = 0; j < 4; j++)
+    {
+        for(int k = 0; k < 1000000; k++)
+        {
+            < Loop Code >
+        }
+    }
+}
+```
+
+The middle loop is very small, and will most likely not benefit from parallelization. To fix this, we may apply the `seq` clause as follows:
+
+```cpp
+#pragma acc parallel loop
+for(int i = 0; i < 1000000; i++)
+{
+    #pragma acc loop seq
+    for(int j = 0; j < 4; j++)
+    {
+        #pragma acc loop
+        for(int k = 0; k < 1000000; k++)
+        {
+            < Loop Code >
+        }
+    }
+}
+```
+
+In this code snippet, the middle loop will be run sequentially, while the outer-most loop and inner-most loop will be run in parallel.
+
+### Reduction Clause
+
+Up to this point, we have technically been using the `reduction` clause in our laplace code. We were not explicitly defining the reduction, instead the compiler has been automatically applying the reduction clause to our code. Let's look at one of the loops from within our `laplace2d.c` code file.
+
+```cpp
+#pragma acc parallel loop present(A,Anew)
+for( int j = 1; j < n-1; j++
+{
+    #pragma acc loop
+    for( int i = 1; i < m-1; i++ )
+    {
+        Anew[OFFSET(j, i, m)] = 0.25 * ( A[OFFSET(j, i+1, m)] + A[OFFSET(j, i-1, m)] 
+                                       + A[OFFSET(j-1, i, m)] + A[OFFSET(j+1, i, m)] );
+        error = fmax( error, fabs(Anew[OFFSET(j, i, m)] - A[OFFSET(j, i , m)]));
+    }
+}
+```
+
+More specifically, let's focus on this single line of code:
+
+```cpp
+error = fmax( error, fabs(Anew[OFFSET(j, i, m)] - A[OFFSET(j, i , m)]));
+```
+
+Each iteration of our inner-loop will write to the value `error`. When we are running thousands of these loop iterations **simultaneously**, it can become very dangerous to let all of them write directly to `error`. To fix this, we must use the OpenACC `reduction` clause. Let's look at the syntax.
+
+```cpp
+#pragma acc parallel loop reduction(operator:value)
+```
+
+And let's look at a quick example of the use.
+
+```ccp
+#pragma acc parallel loop reduction(+:sum)
+for(int i = 0; i < N; i++)
+{
+    sum += A[i];
+}
+```
+
+This is a list of all of the available operators in OpenACC.
+
+|Operator    |Example                     |Description           |
+|:----------:|:---------------------------|:---------------------|
+|+           |reduction(+:sum)            |Mathematical summation|
+|*           |reduction(*:product)        |Mathematical product  |
+|max         |reduction(max:maximum)      |Maximum value         |
+|min         |reduction(min:minimum)      |Minimum value         |
+|&           |reduction(&:val)            |Bitwise AND           |
+|&#124;      |reduction(&#124;:val)       |Bitwise OR            |
+|&&          |reduction(&&:bool)          |Logical AND           |
+|&#124;&#124;|reduction(&#124;&#124;:bool)|Logical OR            |
+
+#### Optional: Implementing the Reduction Clause
+
+We are compiling our code with the PGI compiler, which is automatically able to include the reduction clause. However, in other compilers, we may not be as fortunate. Use the following link to add the `reduction` clause with the `max` operator to our code.
+
+[laplace2d.c](../../../../edit/module6/English/C/laplace2d.c)  
+(make sure to save your code with ctrl+s)
+
+You may then run the following script to verify that the compiler is properly recognizing your reduction clause.
+
+
+```bash
+$ pgcc -ta=tesla -Minfo=accel -o laplace_reduction jacobi.c laplace2d.c && ./laplace_reduction
+```
+
+You may also check your answer by selecting the following link.
+
+[laplace2d.c](../../../../edit/module6/English/C/solutions/reduction/laplace2d.c)
+
+### Private Clause
+
+The private clause allows us to mark certain variables (and even arrays) as *"private"*. The best way to visualize it is with an example:
+
+```cpp
+int tmp;
+
+#pragma acc parallel loop private(tmp)
+for(int i = 0; i < N/2; i++)
+{
+    tmp = A[i];
+    A[i] = A[N-i-1];
+    A[N-i-1] = tmp;
+}
+```
+
+In this code, each thread will have its own *private copy of tmp*. You may also declare static arrays as private, like this:
+
+```cpp
+int tmp[10];
+
+#pragma acc parallel loop private(tmp[0:10])
+for(int i = 0; i < N; i++)
+{
+    < Loop code that uses the tmp array >
+}
+```
+
+When using *private variables*, the variable only exists within the private scope. This generally means that the private variable only exists for a single loop iteration, and the values you store in the private variable cannot extend out of the loop.
+
+### Collapse Clause
+
+This is our first true *loop optimization*. The `collapse` clause allows us to transform a multi-dimensional loop nests into a single-dimensional loop. This process is helpful for increasing the overall length (which usually increases parallelism) of our loops, and will often help with memory locality. Let's look at the syntax.
+
+```cpp
+#pragma acc parallel loop collapse( N )
+```
+
+Where N is the number of loops to collapse.
+
+```cpp
+#pragma acc parallel loop collapse( 3 )
+for(int i = 0; i < N; i++)
+{
+    for(int j = 0; j < M; j++)
+    {
+        for(int k = 0; k < Q; k++)
+        {
+            < loop code >
+        }
+    }
+}
+```
+
+This code will combine the 3-dimensional loop nest into a single 1-dimensional loop. It is important to note that when using the `collapse` clause, the inner loops should not have their own `loop` directive. What this means is that the following code snippet is **incorrect** and will give a warning when compiling.
+
+```cpp
+#pragma acc parallel loop collapse( 3 )
+for(int i = 0; i < N; i++)
+{
+    #pragma acc loop
+    for(int j = 0; j < M; j++)
+    {
+        #pragma acc loop
+        for(int k = 0; k < Q; k++)
+        {
+            < loop code >
+        }
+    }
+}
+```
+
+#### Implementing the Collapse Clause
+
+Use the following link to edit our code. Use the `collapse` clause to collapse our multi-dimensional loops into a single dimensional loop.
+
+[laplace2d.c](../../../../edit/module6/English/C/laplace2d.c)  
+(make sure to save your code with ctrl+s)
+
+Then run the following script to see how the code runs.
+
+
+```bash
+$ pgcc -ta=tesla -Minfo=accel -o laplace_collapse jacobi.c laplace2d.c && ./laplace_collapse
+```
+
+### Tile Clause
+
+The `tile` clause allows us to break up a multi-dimensional loop into *tiles*, or *blocks*. This is often useful for increasing memory locality in some codes. Let's look at the syntax.
+
+```cpp
+#pragma acc parallel loop tile( x, y, z, ... )
+```
+
+Our tiles can have as many dimensions as we want, though we must be careful to not create a tile that is too large. Let's look at an example:
+
+```cpp
+#pragma acc parallel loop tile( 32, 32 )
+for(int i = 0; i < N; i++)
+{
+    for(int j = 0; j < M; j++)
+    {
+        < loop code >
+    }
+}
+```
+
+The above code will break our loop iterations up into 32x32 tiles (or blocks), and then execute those blocks in parallel. Let's look at a slightly more specific code.
+
+```cpp
+#pragma acc parallel loop tile( 32, 32 )
+for(int i = 0; i < 128; i++)
+{
+    for(int j = 0; j < 128; j++)
+    {
+        < loop code >
+    }
+}
+```
+
+In this code, we have 128x128 loop iterations, which are being broken up into 32x32 tiles. This means that we will have 16 tiles, each tile being size 32x32. Similar to the `collapse` clause, the inner loops should not have the `loop` directive. This means that the following code is **incorrect** and will give a warning when compiling.
+
+```cpp
+#pragma acc parallel loop tile( 32, 32 )
+for(int i = 0; i < N; i++)
+{
+    #pragma acc loop
+    for(int j = 0; j < M; j++)
+    {
+        < loop code >
+    }
+}
+```
+
+#### Implementing the Tile Clause
+
+Use the following link to edit our code. Replace the `collapse` clause with the `tile` clause to break our multi-dimensional loops into smaller tiles. Try using a variety of different tile sizes, but always keep one of the dimensions as a **multiple of 32**. We will talk later about why this is important.
+
+[laplace2d.c](../../../../edit/module6/English/C/laplace2d.c)  
+(make sure to save your code with ctrl+s)
+
+Then run the following script to see how the code runs.
+
+
+```bash
+$ pgcc -ta=tesla -Minfo=accel -o laplace_tile jacobi.c laplace2d.c && ./laplace_tile
+```
+
+### Gang/Worker/Vector
+
+This is our last optimization, and arguably the most important one. In OpenACC, the concepts of *Gang*, *Worker*, and *Vector* are used to define additional levels of parallelism. Specifically for NVIDIA GPUs, gang worker vector will define the *organization* of our GPU threads (or sometimes referred to as the *decomposition* of or loop iterations). Each loop will have an optimal Gang Worker Vector implementation, and finding that correct implementation will often take a bit of thinking, and possibly some trial and error. So let's explain how Gang Worker Vector actually works.
+
+![gang_worker_vector.png](../images/gang_worker_vector.png)
+
+This image represents a single **gang**. When parallelizing our **for loops**, the **loop iterations** will be **broken up evenly** among a number of gangs. Each gang will contain a number of **threads**. These threads are organized into **blocks**. A **worker** is a row of threads. In the above graphic, there are 3 **workers**, which means that there are 3 rows of threads. The **vector** refers to how long each row is. So in the above graphic, the vector is 8, because each row is 8 threads long.
+
+By default, when programming for a GPU, **gang** and **vector** paralleism is automatically applied. Let's see a simple GPU sample code where we explicitly show how the gang and vector works.
+
+```cpp
+#pragma acc parallel loop gang
+for(int i = 0; i < N; i++)
+{
+    #pragma acc loop vector
+    for(int j = 0; j < M; j++)
+    {
+        < loop code >
+    }
+}
+```
+
+The outer loop will be evenly spread across a number of **gangs**. Then, within those gangs, the inner-loop will be executed in parallel across the **vector**. This is a process that usually happens automatically, however, we can usually achieve better performance by optimzing the gang worker vector ourselves.
+
+Lets look at an example where using gang worker vector can greatly increase a loops parallelism.
+
+```cpp
+#pragma acc parallel loop gang
+for(int i = 0; i < N; i++)
+{
+    #pragma acc loop vector
+    for(int j = 0; j < M; k++)
+    {
+        for(int k = 0; k < Q; k++)
+        {
+            < loop code >
+        }
+    }
+}
+```
+
+In this loop, we have **gang-level** parallelism on the outer-loop, and **vector-level** parallelism on the middle-loop. However, the inner-loop does not have any parallelism. This means that each thread will be running the inner-loop, however, GPU threads aren't really made to run entire loops. To fix this, we could use **worker-level** parallelism to add another layer.
+
+```cpp
+#pragma acc parallel loop gang
+for(int i = 0; i < N; i++)
+{
+    #pragma acc loop worker
+    for(int j = 0; j < M; k++)
+    {
+        #pragma acc loop vector
+        for(int k = 0; k < Q; k++)
+        {
+            < loop code >
+        }
+    }
+}
+```
+
+Now, the outer-loop will be split across the gangs, the middle-loop will be split across the workers, and the inner loop will be executed by the threads within the vector.
+
+#### Gang, Worker, Vector Syntax
+
+We have been showing really general examples of gang worker vector so far. One of the largest benefits of gang worker vector is the ability to explicitly define how many gangs and workers you need, and how many threads should be in the vector. Let's look at the syntax for the `parallel` directive:
+
+```cpp
+#pragma acc parallel num_gangs( 2 ) num_workers( 4 ) vector_length( 32 )
+{
+    #pragma acc loop gang worker
+    for(int i = 0; i < N; i++)
+    {
+        #pragma acc loop vector
+        for(int j = 0; j < M; j++)
+        {
+            < loop code >
+        }
+    }
+}
+```
+
+And now the syntax for the `kernels` directive:
+
+```cpp
+#pragma acc kernels loop gang( 2 ) worker( 4 )
+for(int i = 0; i < N; i++)
+{
+    #pragma acc loop vector( 32 )
+    for(int j = 0; j < M; j++)
+    {
+        < loop code >
+    }
+}
+```
+
+#### Avoid Wasting Threads
+
+When parallelizing small arrays, you have to be careful that the number of threads within your vector is not larger than the number of loop iterations. Let's look at a simple example:
+
+```cpp
+#pragma acc kernels loop gang
+for(int i = 0; i < 1000000000; i++)
+{
+    #pragma acc loop vector(256)
+    for(int j = 0; j < 32; j++)
+    {
+        < loop code >
+    }
+}
+```
+
+In this code, we are parallelizing an inner-loop that has 32 iterations. However, our vector is 256 threads long. This means that when we run this code, we will have a lot more threads than loop iterations, and a lot of the threads will be sitting idly. We could fix this in a few different ways, but let's use **worker-level parallelism** to fix it.
+
+```cpp
+#pragma acc kernels loop gang worker(8)
+for(int i = 0; i < 1000000000; i++)
+{
+    #pragma acc loop vector(32)
+    for(int j = 0; j < 32; j++)
+    {
+        < loop code >
+    }
+}
+```
+
+Originally we had 1 (implied) worker, that contained 256 threads. Now, we have 8 workers that each have only 32 threads. We have eliminated all of our wasted threads by reducing the length of the **vector** and increasing the number of **workers**.
+
+#### The Rule of 32 (Warps)
+
+The general rule of thumb for programming for NVIDIA GPUs is to always ensure that your vector length is a multiple of 32 (which means 32, 64, 96, 128, ... 512, ... 1024... etc.). This is because NVIDIA GPUs are optimized to use *warps*. Warps are groups of 32 threads that are executing the same computer instruction. So as a reference:
+
+```cpp
+#pragma acc kernels loop gang
+for(int i = 0; i < N; i++)
+{
+    #pragma acc loop vector(32)
+    for(int j = 0; j < M; j++)
+    {
+        < loop code >
+    }
+}
+```
+
+will perform much better than:
+
+```cpp
+#pragma acc kernels loop gang
+for(int i = 0; i < N; i++)
+{
+    #pragma acc loop vector(31)
+    for(int j = 0; j < M; j++)
+    {
+        < loop code >
+    }
+}
+```
+
+#### Implementing the Gang, Worker, and Vector Clauses
+
+Use the following link to edit our code. Replace our ealier clauses with **gang, worker, and vector** To reorganize our thread blocks. Try it using a few different numbers, but always keep the vector length as a **multiple of 32** to fully utilize **warps**.
+
+[laplace2d.c](../../../../edit/module6/English/C/laplace2d.c)  
+(make sure to save your code with ctrl+s)
+
+Then run the following script to see how the code runs.
+
+
+```bash
+$ pgcc -ta=tesla -Minfo=accel -o laplace_gang_worker_vector jacobi.c laplace2d.c && ./laplace_gang_worker_vector
+```
+
+## Using Everything we Learned
+
+Now that we have covered the various ways to edit our loops, apply this knowledge to our laplace code. Try mixing some of the loop clauses, and see how the loop optimizations will differ between the parallel and the kernels directive.
+
+You may run the following script to reset your code with the `kernels` directive.
+
+
+```bash
+$ cp ./solutions/base_parallel/kernels/laplace2d.c ./laplace2d.c && echo "Reset Finished"
+```
+
+You may run the following script to reset your code with the `parallel` directive.
+
+
+```bash
+$ cp ./solutions/base_parallel/parallel/laplace2d.c ./laplace2d.c && echo "Reset Finished"
+```
+
+Then use the following link to edit our laplace code.
+
+[laplace2d.c](../../../../edit/module6/English/C/laplace2d.c)  
+(make sure to save your code with ctrl+s)
+
+Then run the following script to see how the code runs.
+
+
+```bash
+$ pgcc -ta=tesla -Minfo=accel -o laplace jacobi.c laplace2d.c && ./laplace
+```
+
+---
+
+## Conclusion
+
+Our primary goal when using OpenACC is to parallelize our large for loops. To accomplish this, we must use the OpenACC `loop` directive and loop clauses. There are many ways to alter and optimize our loops, though it is up to the programmer to decide which route is the best to take. At this point in the lab series, you should be able to begin parallelizing your own personal code, and to be able to achieve a relatively high performance using OpenACC.
+
+---
+
+## Bonus Task
+
+If you would like some additional lessons on using OpenACC, there is an Introduction to OpenACC video series available from the OpenACC YouTube page. If you haven't already, I recommend watching this 6 part series. Each video is under 10 minutes, and will give a visual, and hands-on look at a lot of the material we have covered in these labs. The following link will bring you to Part 1 of the series.
+
+[Introduction to Parallel Programming with OpenACC - Part 1](https://youtu.be/PxmvTsrCTZg)  
+
+## Post-Lab Summary
+
+If you would like to download this lab for later viewing, it is recommend you go to your browsers File menu (not the Jupyter notebook file menu) and save the complete web page.  This will ensure the images are copied down as well.
+
+You can also execute the following cell block to create a zip-file of the files you've been working on, and download it with the link below.
+
+
+```python
+%%bash
+rm -f openacc_files.zip
+zip -r openacc_files.zip *
+```
+
+**After** executing the above zip command, you should be able to download the zip file [here](files/openacc_files.zip)
+
+# Licensing
+This material is released by NVIDIA Corporation under the Creative Commons Attribution 4.0 International (CC BY 4.0).

--- a/labs/module6/English/Fortran/README.md
+++ b/labs/module6/English/Fortran/README.md
@@ -1,0 +1,584 @@
+# OpenACC Loop Optimizations
+
+This version of the lab is intended for Fortran programmers. The C/C++ version of this lab is available [here](../C/README.md).
+
+You will receive a warning five minutes before the lab instance shuts down. Remember to save your work! If you are about to run out of time, please see the [Post-Lab](#Post-Lab-Summary) section for saving this lab to view offline later.
+
+Don't forget to check out additional [OpenACC Resources](https://www.openacc.org/resources) and join our [OpenACC Slack Channel](https://www.openacc.org/community#slack) to share your experience and get more help from the community.
+
+---
+Let's execute the cell below to display information about the GPUs running on the server. To do this, execute the cell block below by giving it focus (clicking on it with your mouse), and hitting Ctrl-Enter, or pressing the play button in the toolbar above.  If all goes well, you should see some output returned below the grey cell.
+
+
+```bash
+$ pgaccelinfo
+```
+
+---
+
+## Introduction
+
+Our goal for this lab is to use the OpenACC Loop clauses to opimize our Parallel Loops.
+  
+  
+  
+![development_cycle.png](../images/development_cycle.png)
+
+This is the OpenACC 3-Step development cycle.
+
+**Analyze** your code, and predict where potential parallelism can be uncovered. Use profiler to help understand what is happening in the code, and where parallelism may exist.
+
+**Parallelize** your code, starting with the most time consuming parts. Focus on maintaining correct results from your program.
+
+**Optimize** your code, focusing on maximizing performance. Performance may not increase all-at-once during early parallelization.
+
+We are currently tackling the **optimize** step. We will include the OpenACC loop clauses to optimize the execution of our parallel loop nests.
+
+---
+
+## Run the Code
+
+In the previous labs, we have built up a working parallel code that can run on both a multicore CPU and a GPU. Let's run the code and note the performance, so that we can compare the runtime to any future optimizations we make.
+
+
+```bash
+$ pgfortran -fast -ta=tesla -Minfo=accel -o laplace_baseline jacobi.f90 laplace2d.f90 && ./laplace_baseline
+```
+
+### Optional: Analyze the Code
+
+If you would like a refresher on the code files that we are working on, you may view both of them using the two links below.
+
+[jacobi.f90](../../../../edit/module6/English/Fortran/jacobi.f90)  
+[laplace2d.f90](../../../../edit/module6/English/Fortran/laplace2d.f90)  
+
+### Optional: Profile the Code
+
+If you would like to profile the code, you may select <a href="/vnc" target="_blank">this link.</a> When prompted for a password, type `openacc`. This will open a noVNC window, then you may use PGPROF to profile our laplace code. The executable will be found in the `/home/openacc/labs/module6/English/Fortran` directory.
+
+---
+
+## OpenACC Loop Directive
+
+The loop directive allows us to mark specific loops for parallelization. The loop directive also allows us to map specific optimizations/alterations to our loops using **loop clauses**. Not all loop clauses are used to optimize our code; some are also used to verify code correctness. A few examples of the loop directive are as follows:
+
+```fortran
+!$acc parallel loop < loop clauses >
+do i = 1, N
+    < loop code >
+end do
+```
+
+```fortran
+!$acc kernels loop < loop clauses >
+do i = 1, N
+    < loop code >
+end do
+```
+
+```fortran
+!$acc parallel loop < loop clauses >
+do i = 1, N
+    !$acc loop < loop clauses >
+    do j = 1, M
+        < loop code >
+    end do
+end do
+```
+
+Also, including loop optimizations does not always optimize the code. It is up to the programmer to decide which loop optimizations will work best for their loops.
+
+### Independent Clause
+
+When using the `kernels` directive, the compiler will decide which loops are, and are not, parallelizable. However, the programmer can override this compiler decision by using the `independent` clause. The independent clause is a way for the programmer to guarantee to the compiler that a loop is **parallelizable**.
+
+```fortran
+!$acc kernels loop independent
+do i = 1, N
+    < Parallel Loop Code >
+end do
+
+!$acc kernels
+    do i = 1, N
+        < Parallel Loop Code >
+    end do
+    
+    !$acc loop independent
+    do i = 1, N
+        < Parallel Loop Code >
+    end do
+!$acc end kernels
+```
+
+In the second example, we have two loops. The compiler will make a decision whether or not the first loop is parallelizable. In the second loop however, we have included the `independent` clause. This means that the compiler will trust the programmer, and assume that the second loop is parallelizable.
+
+When using the `parallel` directive, the independent clause is automatically implied on `loop` directives contained within. This means that you do not need to use the `independent` clause when you are using the `parallel` directive.
+
+### Auto Clause
+
+The `auto` clause is more-or-less the complete opposite of the `independent` clause. When you are using the `parallel` directive, the compiler will trust anything that the programmer decides. This means that if the programmer believes that a loop is parallelizable, the compiler will trust the programmer. However, if you include the auto clause with your loops, the compiler will double check the loops, and decide whether or not to parallelize them.
+
+```fortran
+!$acc parallel loop auto
+do i = 1, N
+    < Parallel Loop Code >
+end do
+```
+
+The `independent` clause is a way for the programmer to assert to the compiler that a loop is parallelizable. The `auto` clause is a way for the programmer to tell the compiler to analyze the loop, and to determine whether or not it is parallelizable.
+
+### Seq Clause
+
+The `seq` clause (short for *"sequential"*) is used to define a loop that should run sequentially on the parallel hardware. This loop clause is usually automatically applied to large, multidimensional loop nests, since the compiler may only be able to describe parallelism for the outer-most loops. For example:
+
+```fortran
+do i = 1, N
+    do j = 1, M
+        do k = 1, Q
+            < Loop Code >
+        end do
+    end do
+end do
+```
+
+The compiler may only be able to parallelize the `i` and `j` loops, and will choose to run the `k` loop *sequentially*. The `seq` clause is also useful for running very small, nested loops sequentially. For example:
+
+```fortran
+do i = 1, 1000000
+    do j = 1, 4
+        do k = 1, 1000000
+            < Loop Code >
+        end do
+    end do
+end do
+```
+
+The middle loop is very small, and will most likely not benefit from parallelization. To fix this, we may apply the `seq` clause as follows:
+
+```fortran
+!$acc parallel loop
+do i = 1, 1000000
+    !$acc loop seq
+    do j = 1, 4
+        !$acc loop
+        do k = 1, 1000000
+            < Loop Code >
+        end do
+    end do
+end do
+```
+
+In this code snippet, the middle loop will be run sequentially, while the outer-most loop and inner-most loop will be run in parallel.
+
+### Reduction Clause
+
+Up to this point, we have technically been using the `reduction` clause in our laplace code. We were not explicitly defining the reduction, instead the compiler has been automatically applying the reduction clause to our code. Let's look at one of the loops from within our laplace2d.c code file.
+
+```fortran
+!$acc parallel loop present(A,Anew)
+do j=1,m-2
+    do i=1,n-2
+        Anew(i,j) = 0.25_fp_kind * ( A(i+1,j  ) + A(i-1,j  ) + &
+                                     A(i  ,j-1) + A(i  ,j+1) )
+        error = max( error, abs(Anew(i,j)-A(i,j)) )
+    end do
+end do
+```
+
+More specifically, let's focus on this single line of code:
+
+```fortran
+error = max( error, abs(Anew(i,j)-A(i,j)) )
+```
+
+Each iteration of our inner-loop will write to the value `error`. When we are running thousands of these loop iterations **simultaneously**, it can become very dangerous to let all of them write directly to `error`. To fix this, we must use the OpenACC `reduction` clause. Let's look at the syntax.
+
+```fortran
+!$acc parallel loop reduction(operator:value)
+```
+
+And let's look at a quick example of the use.
+
+```fortran
+!$acc parallel loop reduction(+:sum)
+do i = 1, N
+    sum = sum + A(i)
+end do
+```
+
+This is a list of all of the available operators in OpenACC.
+
+|Operator    |Example                     |Description           |
+|:----------:|:---------------------------|:---------------------|
+|+           |reduction(+:sum)            |Mathematical summation|
+|*           |reduction(*:product)        |Mathematical product  |
+|max         |reduction(max:maximum)      |Maximum value         |
+|min         |reduction(min:minimum)      |Minimum value         |
+|&           |reduction(&:val)            |Bitwise AND           |
+|&#124;      |reduction(&#124;:val)       |Bitwise OR            |
+|&&          |reduction(&&:bool)          |Logical AND           |
+|&#124;&#124;|reduction(&#124;&#124;:bool)|Logical OR            |
+
+#### Optional: Implementing the Reduction Clause
+
+We are compiling our code with the PGI compiler, which is automatically able to include the reduction clause. However, in other compilers, we may not be as fortunate. Use the following link to add the `reduction` clause with the `max` operator to our code.
+
+[laplace2d.f90](../../../../edit/module6/English/Fortran/laplace2d.f90)  
+(make sure to save your code with ctrl+s)
+
+You may then run the following script to verify that the compiler is properly recognizing your reduction clause.
+
+
+```bash
+$ pgfortran -ta=tesla -Minfo=accel -o laplace_reduction jacobi.f90 laplace2d.f90 && ./laplace_reduction
+```
+
+You may also check your answer by selecting the following link.
+
+[laplace2d.f90](../../../../edit/module6/English/Fortran/solutions/reduction/laplace2d.f90)
+
+### Private Clause
+
+The private clause allows us to mark certain variables (and even arrays) as *"private"*. The best way to visualize it is with an example:
+
+```fortran
+int tmp;
+
+!$acc parallel loop private(tmp)
+do i = 1, N/2
+    tmp = A(i)
+    A(i) = A(N-i-1)
+    A(N-i-1) = tmp;
+end do
+```
+
+In this code, each thread will have its own *private copy of tmp*. You may also declare static arrays as private, like this:
+
+```fortran
+integer :: tmp(10)
+
+!$acc parallel loop private(tmp(1:10))
+do i = 1, N
+    < Loop code that uses the tmp array >
+end do
+```
+
+When using *private variables*, the variable only exists within the private scope. This generally means that the private variable only exists for a single loop iteration, and the values you store in the private variable cannot extend out of the loop.
+
+### Collapse Clause
+
+This is our first true *loop optimization*. The `collapse` clause allows us to transform a multi-dimensional loop nests into a single-dimensional loop. This process is helpful for increasing the overall length (which usually increases parallelism) of our loops, and will often help with memory locality. Let's look at the syntax.
+
+```fortran
+!$acc parallel loop collapse( N )
+```
+
+Where N is the number of loops to collapse.
+
+```fortran
+!$acc parallel loop collapse( 3 )
+do i = 1, N
+    do j = 1, M
+        do k = 1, Q
+            < loop code >
+        end do
+    end do
+end do
+```
+
+This code will combine the 3-dimensional loop nest into a single 1-dimensional loop. It is important to note that when using the `collapse` clause, the inner loops should not have their own `loop` directive. What this means is that the following code snippet is **incorrect** and will give a warning when compiling.
+
+```fortran
+!$acc parallel loop collapse( 3 )
+do i = 1, N
+    !$acc loop
+    do j = 1, M
+        !$acc loop
+        do k = 1, Q
+            < loop code >
+        end do
+    end do
+end do
+```
+
+#### Implementing the Collapse Clause
+
+Use the following link to edit our code. Use the `collapse clause`
+to collapse our multi-dimensional loops into a single dimensional loop.
+
+[laplace2d.f90](../../../../edit/module6/English/Fortran/laplace2d.f90)  
+(make sure to save your code with ctrl+s)
+
+Then run the following script to see how the code runs.
+
+
+```bash
+$ pgfortran -ta=tesla -Minfo=accel -o laplace_collapse jacobi.f90 laplace2d.f90 && ./laplace_collapse
+```
+
+### Tile Clause
+
+The `tile` clause allows us to break up a multi-dimensional loop into *tiles*, or *blocks*. This is often useful for increasing memory locality in some codes. Let's look at the syntax.
+
+```fortran
+!$acc parallel loop tile( x, y, z, ... )
+```
+
+Our tiles can have as many dimensions as we want, though we must be careful to not create a tile that is too large. Let's look at an example:
+
+```fortran
+!$acc parallel loop tile( 32, 32 )
+do = 1, N
+    do j = 1, M
+        < loop code >
+    end do
+end do
+```
+
+The above code will break our loop iterations up into 32x32 tiles (or blocks), and then execute those blocks in parallel. Let's look at a slightly more specific code.
+
+```fortran
+!$acc parallel loop tile( 32, 32 )
+do i = 1, 128
+    do j = 1, 128
+        < loop code >
+    end do
+end do
+```
+
+In this code, we have 128x128 loop iterations, which are being broken up into 32x32 tiles. This means that we will have 16 tiles, each tile being size 32x32. Similar to the `collapse` clause, the inner loops should not have the `loop` directive. This means that the following code is **incorrect** and will give a warning when compiling.
+
+```fortran
+!$acc parallel loop tile( 32, 32 )
+do i = 1, N
+    !$acc loop
+    do j = 1, M
+        < loop code >
+    end do
+end do
+```
+
+#### Implementing the Tile Clause
+
+Use the following link to edit our code. Replace the  `collapse`clause with the `tile` clause to break our multi-dimensional loops into smaller tiles. Try using a variety of different tile sizes, but always keep one of the dimensions as a **multiple of 32**. We will talk later about why this is important.
+
+[laplace2d.f90](../../../../edit/module6/English/C/laplace2d.f90)  
+(make sure to save your code with ctrl+s)
+
+Then run the following script to see how the code runs.
+
+
+```bash
+$ pgfortran -ta=tesla -Minfo=accel -o laplace_tile jacobi.f90 laplace2d.f90 && ./laplace_tile
+```
+
+### Gang/Worker/Vector
+
+This is our last optimization, and arguably the most important one. In OpenACC the concepts of *Gang*, *Worker*, and  *Vector* are used to define additional levels of parallelism. Specifically for NVIDIA GPUs, gang worker vector will define the *organization* of our GPU threads (or sometimes referred to as the *decomposition* of our loop iterations). Each loop will have an optimal Gang, Worker, and/or Vector implementation, and finding that correct implementation will often take a bit of thinking, and possibly some trial and error. So let's explain how Gangs, Workers, and Vectors actually work.
+
+![gang_worker_vector.png](../images/gang_worker_vector.png)
+
+This image represents a single **gang**. When parallelizing our **for loops**, the **loop iterations** will be **broken up evenly** among a number of gangs. Each gang will contain a number of **threads**. These threads are organized into **blocks**. A **worker** is a row of threads. In the above graphic, there are 3 **workers**, which means that there are 3 rows of threads. The **vector** refers to how long each row is. So in the above graphic, the vector is 8, because each row is 8 threads long.
+
+By default, when programming for a GPU, **gang** and **vector** paralleism is automatically applied. Let's see a simple GPU sample code where we explicitly show how the gang and vector works.
+
+```fortran
+!$acc parallel loop gang
+do i = 1, N
+    !$acc loop vector
+    do j = 1, M
+        < loop code >
+    end do
+end do
+```
+
+The outer loop will be evenly spread across a number of **gangs**. Then, within those gangs, the inner-loop will be executed in parallel across the **vector**. This is a process that usually happens automatically, however, we can usually achieve better performance by optimzing the gang worker vector ourselves.
+
+Lets look at an example where using gang worker vector can greatly increase a loops parallelism.
+
+```fortran
+!$acc parallel loop gang
+do i = 1, < N
+    !$acc loop vector
+    do j = 1, M
+        do k = 1, Q
+            < loop code >
+        end do
+    end do
+end do
+```
+
+In this loop, we have **gang-level** parallelism on the outer-loop, and **vector-level** parallelism on the middle-loop. However, the inner-loop does not have any parallelism. This means that each thread will be running the inner-loop, however, GPU threads aren't really made to run entire loops. To fix this, we could use **worker-level** parallelism to add another layer.
+
+```fortran
+!$acc parallel loop gang
+do i = 1, N
+    !$acc loop worker
+    do j = 1, M
+        !$acc loop vector
+        do k = 1, Q
+            < loop code >
+        end do
+    end do
+end do
+```
+
+Now, the outer-loop will be split across the gangs, the middle-loop will be split across the workers, and the inner loop will be executed by the threads within the vector.
+
+#### Gang, Worker, and Vector Syntax
+
+We have been showing really general examples of gangs, worker, and vectors so far. One of the largest benefits of these concepts is the ability to explicitly define how many gangs and workers you need, and how many threads should be in the vector. Let's look at the syntax for the `parallel` directive:
+
+```fortran
+!$acc parallel num_gangs( 2 ) num_workers( 4 ) vector_length( 32 )
+    !$acc loop gang worker
+    do i = 1, N
+        !$acc loop vector
+        do j = 1, M
+            < loop code >
+        end do
+    end do
+!$acc end parallel
+```
+
+And now the syntax for the `kernels` directive:
+
+```fortran
+!$acc kernels loop gang( 2 ) worker( 4 )
+do i = 1, N
+    !$acc loop vector( 32 )
+    do j = 1, M
+        < loop code >
+    end do
+end do
+```
+
+#### Avoid Wasting Threads
+
+When parallelizing small arrays, you have to be careful that the number of threads within your vector is not larger than the number of loop iterations. Let's look at a simple example:
+
+```fortran
+!$acc kernels loop gang
+do i = 1, 1000000000
+    !$acc loop vector(256)
+    do j = 1, 32
+        < loop code >
+    end do
+end do
+```
+
+In this code, we are parallelizing an inner-loop that has 32 iterations. However, our vector is 256 threads long. This means that when we run this code, we will have a lot more threads than loop iterations, and a lot of the threads will be sitting idly. We could fix this in a few different ways, but let's use *worker-level parallelism* to fix it.
+
+```fortran
+!$acc kernels loop gang worker(8)
+do i = 1, 1000000000
+    !$acc loop vector(32)
+    do j = 1, 32
+        < loop code >
+    end do
+end do
+```
+
+Originally we had 1 (implied) worker, that contained 256 threads. Now, we have 8 workers that each have only 32 threads. We have eliminated all of our wasted threads by reducing the length of the *vector* and increasing the number of *workers*.
+
+#### The Rule of 32 (Warps)
+
+The general rule of thumb for programming for NVIDIA GPUs is to always ensure that your vector length is a multiple of 32 (which means 32, 64, 96, 128, ... 512, ... 1024... etc.). This is because NVIDIA GPUs are optimized to use *warps*. Warps are groups of 32 threads that are executing the same computer instruction. So as a reference:
+
+```fortran
+!$acc kernels loop gang
+do i = 1, N
+    !$acc loop vector(32)
+    do j = 1, M
+        < loop code >
+    end do
+end do
+```
+
+will perform much better than:
+
+```fortran
+!$acc kernels loop gang
+do i = 1, N
+    !$acc loop vector(31)
+    do j = 1, M
+        < loop code >
+    end do
+end do
+```
+
+#### Implementing the Gang, Worker, and Vector Clauses
+
+Use the following link to edit our code. Replace our ealier clauses with `gang`, `worker`, and/or `vector` clauses To reorganize our thread blocks. Try it using a few different numbers, but always keep the vector length as a **multiple of 32** to fully utilize **warps**.
+
+[laplace2d.f90](../../../../edit/module6/English/Fortran/laplace2d.f90)  
+(make sure to save your code with ctrl+s)
+
+Then run the following script to see how the code runs.
+
+
+```bash
+$ pgfortran -ta=tesla -Minfo=accel -o laplace_gang_worker_vector jacobi.f90 laplace2d.f90 && ./laplace_gang_worker_vector
+```
+
+## Using Everything we Learned
+
+Now that we have covered the various ways to edit our loops, apply this knowledge to our laplace code. Try mixing some of the loop clauses, and see how the loop optimizations will differ between the parallel and the kernels directive.
+
+You may run the following script to reset your code with the `kernels` directive.
+
+
+```bash
+$ cp ./solutions/base_parallel/kernels/laplace2d.f90 ./laplace2d.f90 && echo "Reset Finished"
+```
+
+You may run the following script to reset your code with the `parallel directive.
+
+
+```bash
+$ cp ./solutions/base_parallel/parallel/laplace2d.f90 ./laplace2d.f90 && echo "Reset Finished"
+```
+
+Then use the following link to edit our laplace code.
+
+[laplace2d.f90](../../../../edit/module6/English/Fortran/laplace2d.f90)  
+(make sure to save your code with ctrl+s)
+
+Then run the following script to see how the code runs.
+
+
+```bash
+$ pgfortran -ta=tesla -Minfo=accel -o laplace jacobi.f90 laplace2d.f90 && ./laplace
+```
+
+---
+
+## Conclusion
+
+Our primary goal when using OpenACC is to parallelize our large for loops. To accomplish this, we must use the OpenACC loop directive and loop clauses. There are many ways to alter and optimize our loops, though it is up to the programmer to decide which route is the best to take. At this point in the lab series, you should be able to begin parallelizing your own personal code, and to be able to achieve a relatively high performance using OpenACC.
+
+---
+
+## Bonus Task
+
+If you would like some additional lessons on using OpenACC, there is an Introduction to OpenACC video series available from the OpenACC YouTube page. If you haven't already, I recommend watching this 6 part series. Each video is under 10 minutes, and will give a visual, and hands-on look at a lot of the material we have covered in these labs. The following link will bring you to Part 1 of the series.
+
+[Introduction to Parallel Programming with OpenACC - Part 1](https://youtu.be/PxmvTsrCTZg)  
+
+## Post-Lab Summary
+
+If you would like to download this lab for later viewing, it is recommend you go to your browsers File menu (not the Jupyter notebook file menu) and save the complete web page.  This will ensure the images are copied down as well.
+
+You can also execute the following cell block to create a zip-file of the files you've been working on, and download it with the link below.
+
+
+```python
+%%bash
+rm -f openacc_files.zip
+zip -r openacc_files.zip *
+```
+
+**After** executing the above zip command, you should be able to download the zip file [here](files/openacc_files.zip)
+
+# Licensing
+This material is released by NVIDIA Corporation under the Creative Commons Attribution 4.0 International (CC BY 4.0).

--- a/labs/module6/README.md
+++ b/labs/module6/README.md
@@ -1,0 +1,11 @@
+OpenACC Loop Optimizations
+=========================
+
+This lab is meant to accompany Module 6 of the OpenACC.org teaching materials.
+The purpose of this lab is to introduce students to loop optimizations in OpenACC. Lab instructions and source code is available for C/C++ and Fortran.
+
+Please see the following files to begin the lab:
+
+* [C/C++](English/C/README.md)
+* [Fortran](English/Fortran/README.md)
+

--- a/scripts/file_link_preprocessor.py
+++ b/scripts/file_link_preprocessor.py
@@ -1,0 +1,21 @@
+from nbconvert.preprocessors import *
+import re
+
+class FileLinkPreprocessor(Preprocessor):
+    """Fixes file links in markdown"""
+
+    def preprocess_cell(self, cell, resources, index):
+        """
+        Changes **filename.ext ( File -> Open -> filename.ext ) 
+        to a proper link.
+        """
+        MATCHING = '\*\*.*\*\* \(.*File.*\-\>.*Open.*\-\>.*\)'
+        if 'source' in cell and cell.cell_type == "markdown":
+            for found in re.findall(MATCHING,cell.source):
+                linkname = re.split('\*\*',found)[1]
+                filename = re.split('Open.*\-\>',found)[1]
+                filename = filename.strip(')')
+                filename = filename.strip()
+                cell.source = cell.source.replace(found,f'[{linkname}]({filename})')
+        
+        return cell, resources

--- a/scripts/generate_markdown.sh
+++ b/scripts/generate_markdown.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+DIRNAME=$( dirname "${BASH_SOURCE[0]}" )
+if [[ "$#" == "0" ]] ; then
+  echo "Usage: ${BASH_SOURCE[0]} <jupyter notebook files"
+fi
+FILES=$*
+for file in $FILES; do
+  jupyter nbconvert --config $DIRNAME/jupyter_nbconvert_config.py $file
+done

--- a/scripts/image_link_preprocessor.py
+++ b/scripts/image_link_preprocessor.py
@@ -1,0 +1,13 @@
+from nbconvert.preprocessors import *
+import re
+
+class ImageLinkPreprocessor(Preprocessor):
+    """Strips 'files/' from image links"""
+
+    def preprocess_cell(self, cell, resources, index):
+        """Strips 'files/' from image links"""
+        MATCHING = 'files\/images'
+        if 'source' in cell and cell.cell_type == "markdown":
+            cell.source = cell.source.replace('files/images','images')
+        
+        return cell, resources

--- a/scripts/jupyter_nbconvert_config.py
+++ b/scripts/jupyter_nbconvert_config.py
@@ -1,0 +1,12 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+
+# Configuration file for jupyter-nbconvert.
+c.NbConvertApp.export_format = 'markdown'
+c.TagRemovePreprocessor.remove_cell_tags = ("remove_cell",)
+c.TagRemovePreprocessor.enabled = True
+c.FileLinkPreprocessor.enabled = True
+c.ImageLinkPreprocessor.enabled = True
+c.Exporter.default_preprocessors = ['nbconvert.preprocessors.TagRemovePreprocessor', 'file_link_preprocessor.FileLinkPreprocessor', 'image_link_preprocessor.ImageLinkPreprocessor']
+c.NbConvertApp.postprocessor_class = 'lab_postprocessor.LabPostProcessor'

--- a/scripts/lab_postprocessor.py
+++ b/scripts/lab_postprocessor.py
@@ -1,0 +1,13 @@
+from nbconvert.postprocessors import *
+
+class LabPostProcessor(PostProcessorBase):
+    def postprocess(self,fileName):
+        f = open(fileName, "r")
+        data = f.read()
+        f.close()
+        output = data.replace("```python\n!","```bash\n$ ")
+        output = output.replace(".ipynb",".md")
+        f = open(fileName, "w")
+        f.write(output)
+        f.close()
+


### PR DESCRIPTION
This copies the scripts from the bootcamp branch to automatically convert between notebook files and github-friendly markdown files. Some new conventions were added to the contributor guidelines to support these scripts.

Before merging, the download cell at the bottom of each notebook should be tagged to be hidden and the markdown files regenerated. 